### PR TITLE
feat(filterable): support through() method to apply custom builder callbacks

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -90,6 +90,10 @@ export default defineUserConfig({
                         link: "features/aliasing",
                     },
                     {
+                        text: "Through callbacks",
+                        link: "features/through",
+                    },
+                    {
                         text: "Auto Binding",
                         link: "features/auto-binding",
                     },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -82,6 +82,10 @@ export default defineUserConfig({
                         link: "features/auto-register-filterable-macro",
                     },
                     {
+                        text: "Conditional Logic",
+                        link: "features/conditional-logic-with-when",
+                    },
+                    {
                         text: "Filter Aliases",
                         link: "features/aliasing",
                     },

--- a/docs/features/conditional-logic-with-when.md
+++ b/docs/features/conditional-logic-with-when.md
@@ -1,0 +1,54 @@
+# Conditional Logic with **`when`**
+
+## Overview
+
+The `when()` method allows you to conditionally modify the instance based on a boolean expression.
+Instead of writing verbose conditionals, `when()` helps you write expressive, chainable, and concise logic to update your filter configuration.
+Unlike immutability patterns, this method modifies the current instance directly and returns $this, making it perfect for method chaining.
+
+### ✨ Usage
+
+```php
+$filter = Filterable::create()
+    ->when($isAdmin, function (Filterable $filter) {
+    $filter->setAllowedFields(['email', 'role']);
+});
+```
+
+In this example, the setAllowedFields() call is only executed if $isAdmin is true.
+
+### 🔁 Nesting
+
+```php
+Filterable::create()->when(true, function ($filter) {
+    $filter->setAllowedFields(['name']);
+
+    $filter->when(true, function ($filter) {
+        $filter->setAllowedFields(['email', 'phone']);
+
+        $filter->when(true, fn($f) => $f->setAllowedFields(['address']));
+    });
+});
+```
+
+### 🔬 Behavior
+
+If $condition is true → callback is invoked with the current instance.
+
+If $condition is false → nothing happens.
+
+In both cases, the original instance is returned.
+
+### 💡 Benefits
+
+-   ✨ Cleaner Code:
+    Eliminates the need for verbose if conditions. Just chain your logic fluently using when().
+-   🧠 Improved Readability:
+    The code reads naturally, e.g.,
+    “When the condition is true, apply this logic.”
+-   🧪 Easier Testing:
+    Testing conditional filter logic becomes straightforward and expressive.
+-   🔁 Supports Nesting:
+    Allows deeply nested conditional logic while keeping the syntax clean and expressive.
+-   🔗 Chainable Design:
+    when() returns the same instance, enabling seamless method chaining without breaking flow.

--- a/docs/features/through.md
+++ b/docs/features/through.md
@@ -1,0 +1,49 @@
+# Apply Custom Query Callbacks using through()
+
+## Overview
+
+The `through()` method allows you to apply an array of custom query callbacks to the Eloquent builder instance within the `Filterable` class.
+
+This gives you a powerful way to manipulate queries using closures (similar to pipelines), before or after applying filters — enabling advanced use cases such as chaining global conditions, joins, or even reordering logic externally.
+
+### 🧪 Usage
+
+```php
+use Kettasoft\Filterable\Filterable;
+use App\Models\Post;
+
+$filter = Filterable::create()->setBuilder(Post::query());
+
+$results = $filter->through([
+    fn ($builder) => $builder->where('status', 'published'),
+    fn ($builder) => $builder->orderByDesc('created_at'),
+]);
+
+$posts = $results->apply()->get();
+```
+
+You can also chain with other Filterable methods:
+
+```php
+$results = Filterable::create()
+    ->setBuilder(Post::query())
+    ->through([
+        fn ($builder) => $builder->where('is_active', true),
+    ])
+    ->apply();
+```
+
+### ⚠️ Notes
+
+-   Every item in the array passed to through() must be a valid callable.
+-   If a non-callable value is passed, an InvalidArgumentException will be thrown.
+-   Callbacks receive the query builder as the only argument and must return the modified builder.
+-   This method is chainable and returns the Filterable instance.
+
+### 💡 Benefits
+
+-   🔄 Adds a flexible, composable way to extend queries externally.
+-   🧪 Great for injecting reusable query logic without modifying filters.
+-   🚫 Prevents tight coupling between filter logic and query logic.
+-   ✅ Compatible with both eager and late filter application (apply()).
+-   🧱 Clean separation of filtering rules and additional query logic.

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -279,7 +279,7 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   }
 
   /**
-   * Use filter engine.
+   * Override the default engine for this filterable instance.
    * @param \Kettasoft\Filterable\Engines\Foundation\Engine|string $engine
    * @return Filterable
    */

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -220,6 +220,8 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   {
     if ($builder) return $builder;
 
+    if (isset($this->builder)) return $this->builder;
+
     if ($this->model instanceof Model) {
       return $this->model->query();
     }
@@ -289,6 +291,26 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   {
     if ($condition) {
       call_user_func($callback, $this);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Allow the query to pass through a custom pipeline of pipes (callables).
+   *
+   * @param array<callable(\Illuminate\Database\Eloquent\Builder, static): \Illuminate\Database\Eloquent\Builder> $pipes
+   * @return static
+   * @link https://kettasoft.github.io/filterable/features/through
+   */
+  public function through(array $pipes): static
+  {
+    foreach ($pipes as $pipe) {
+      if (! is_callable($pipe)) {
+        throw new \InvalidArgumentException('All pipes passed to `through` must be callable.');
+      }
+
+      $pipe($this->builder, $this);
     }
 
     return $this;

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -279,6 +279,22 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   }
 
   /**
+   * Apply a callback conditionally and return a new modified instance.
+   * @param bool $condition
+   * @param callable(static): void $callback
+   * @return static
+   * @link https://kettasoft.github.io/filterable/features/conditional-logic-with-when
+   */
+  public function when(bool $condition, callable $callback)
+  {
+    if ($condition) {
+      call_user_func($callback, $this);
+    }
+
+    return $this;
+  }
+
+  /**
    * Override the default engine for this filterable instance.
    * @param \Kettasoft\Filterable\Engines\Foundation\Engine|string $engine
    * @return Filterable

--- a/tests/Unit/Filterable/FilterableThroughTest.php
+++ b/tests/Unit/Filterable/FilterableThroughTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class FilterableThroughTest extends TestCase
+{
+  public function test_it_can_apply_filter_callbacks_with_through()
+  {
+    /**
+     * @var Filterable
+     */
+    $filter = Filterable::create()->setBuilder(Post::query());
+
+    $results = $filter->through([
+      fn($builder) => $builder->where('id', 1)
+    ]);
+
+    $this->assertNotEmpty($results->apply()->getBindings());
+  }
+
+  public function test_it_throws_exception_when_through_callback_is_invalid()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    /**
+     * @var Filterable
+     */
+    $filter = Filterable::create()->setBuilder(Post::query());
+
+    $filter->through([
+      'invalid args'
+    ]);
+  }
+}

--- a/tests/Unit/Filterable/FilterableWhenConditionTest.php
+++ b/tests/Unit/Filterable/FilterableWhenConditionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class FilterableWhenConditionTest extends TestCase
+{
+  public function test_it_can_use_singel_when()
+  {
+    $filter = Filterable::create()->when(true, function (Filterable $filter) {
+      $filter->setAllowedFields(['test']);
+    });
+
+    $this->assertNotEmpty($filter->getAllowedFields());
+  }
+
+  public function test_it_cant_invoke_when_callback_with_false_condition()
+  {
+    $filter = Filterable::create()->when(false, function (Filterable $filter) {
+      $filter->setAllowedFields(['test']);
+    });
+
+    $this->assertEmpty($filter->getAllowedFields());
+  }
+
+  public function test_it_can_use_nested_when()
+  {
+    $filter = Filterable::create()->when(true, function (Filterable $filter) {
+      $filter->setAllowedFields(['test1']);
+
+      $filter->when(true, function (Filterable $filter) {
+        $filter->setAllowedFields(['test2', 'test3']);
+
+        $filter->when(true, fn($filter) => $filter->setAllowedFields(['test4']));
+
+        // Not working
+        $filter->when(false, function (Filterable $filter) {
+          $filter->setAllowedFields(['test2', 'test3']);
+        });
+      });
+    });
+
+    $this->assertCount(4, $filter->getAllowedFields());
+  }
+}


### PR DESCRIPTION
# Apply Custom Query Callbacks using through
This PR introduces the through() method to the Filterable class, enabling developers to apply an array of custom query modifications directly on the underlying Eloquent builder.

## ✨ What's Added
- Filterable::through(array $callbacks) method
- Each callback is applied sequentially on the query builder instance
- Validates that each item in the array is a valid callable
- Returns the same Filterable instance to support method chaining

## ✅ Tests
- Added test: test_it_can_filter_with_through
- Added test: test_it_throws_exception_for_invalid_through_callbacks

## 💡 Benefits
- Gives more flexibility to inject dynamic or complex filters
- Keeps logic clean and composable
- Improves testability by isolating custom filter logic in callbacks