### PR TITLE
Add Invoker execution control feature

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,118 +3,128 @@ import { defineUserConfig } from "vuepress/cli";
 import { viteBundler } from "@vuepress/bundler-vite";
 
 export default defineUserConfig({
-    lang: "en-US",
+  lang: "en-US",
 
-    title: "Filterable",
-    description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
+  title: "Filterable",
+  description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
 
-    plugins: [
-        {
-            name: "@vuepress/plugin-search",
-        },
-    ],
+  plugins: [
+    {
+      name: "@vuepress/plugin-search",
+    },
+  ],
 
-    theme: defaultTheme({
-        repo: "https://github.com/kettasoft/filterable",
-        // logo: "/docs/logo.png",
+  theme: defaultTheme({
+    repo: "https://github.com/kettasoft/filterable",
+    // logo: "/docs/logo.png",
 
-        colorModeSwitch: true,
-        sidebarDepth: 3,
-        logoAlt: null,
-        logo: null,
-        selectLanguageText: "ar",
-        selectLanguageName: "ar",
-        lastUpdated: true,
-        contributors: true,
-        // contributorsText: "dasdasd",
+    colorModeSwitch: true,
+    sidebarDepth: 3,
+    logoAlt: null,
+    logo: null,
+    selectLanguageText: "ar",
+    selectLanguageName: "ar",
+    lastUpdated: true,
+    contributors: true,
+    // contributorsText: "dasdasd",
 
-        navbar: ["/", "/installation"],
-        sidebar: [
-            {
-                text: "Home",
-                link: "/",
-            },
-            {
-                text: "Introduction",
-                link: "/introduction",
-            },
-            {
-                text: "Installation",
-                link: "/installation",
-            },
-            {
-                text: "How It Works",
-                link: "how-it-works",
-            },
-            {
-                text: "Engines",
-                collapsible: true,
-                children: [
-                    {
-                        text: "Invokable",
-                        link: "engines/invokable",
-                    },
-                    {
-                        text: "Tree",
-                        link: "engines/tree",
-                    },
-                    {
-                        text: "Ruleset",
-                        link: "engines/rule-set",
-                    },
-                    {
-                        text: "Expression",
-                        link: "engines/expression",
-                    },
-                ],
-            },
-            {
-                text: "Features",
-                collapsible: true,
-                children: [
-                    {
-                        text: "Header-Driven Filter Mode",
-                        link: "features/header-driven-filter-mode",
-                    },
-
-                    {
-                        text: "Auto Register Filterable Macro",
-                        link: "features/auto-register-filterable-macro",
-                    },
-                    {
-                        text: "Conditional Logic",
-                        link: "features/conditional-logic-with-when",
-                    },
-                    {
-                        text: "Filter Aliases",
-                        link: "features/aliasing",
-                    },
-                    {
-                        text: "Through callbacks",
-                        link: "features/through",
-                    },
-                    {
-                        text: "Auto Binding",
-                        link: "features/auto-binding",
-                    },
-                ],
-            },
-            {
-                text: "Authorization",
-                link: "authorization",
-            },
-            {
-                text: "Validation",
-                link: "validation",
-            },
-            {
-                text: "Sanitization",
-                link: "sanitization",
-            },
+    navbar: ["/", "/installation"],
+    sidebar: [
+      {
+        text: "Home",
+        link: "/",
+      },
+      {
+        text: "Introduction",
+        link: "/introduction",
+      },
+      {
+        text: "Installation",
+        link: "/installation",
+      },
+      {
+        text: "How It Works",
+        link: "how-it-works",
+      },
+      {
+        text: "Engines",
+        collapsible: true,
+        children: [
+          {
+            text: "Invokable",
+            link: "engines/invokable",
+          },
+          {
+            text: "Tree",
+            link: "engines/tree",
+          },
+          {
+            text: "Ruleset",
+            link: "engines/rule-set",
+          },
+          {
+            text: "Expression",
+            link: "engines/expression",
+          },
         ],
-    }),
+      },
+      {
+        text: "Features",
+        collapsible: true,
+        children: [
+          {
+            text: "Header-Driven Filter Mode",
+            link: "features/header-driven-filter-mode",
+          },
 
-    base: "/filterable",
+          {
+            text: "Auto Register Filterable Macro",
+            link: "features/auto-register-filterable-macro",
+          },
+          {
+            text: "Conditional Logic",
+            link: "features/conditional-logic-with-when",
+          },
+          {
+            text: "Filter Aliases",
+            link: "features/aliasing",
+          },
+          {
+            text: "Through callbacks",
+            link: "features/through",
+          },
+          {
+            text: "Auto Binding",
+            link: "features/auto-binding",
+          },
+        ],
+      },
+      {
+        text: "Execution",
+        collapsible: true,
+        children: [
+          {
+            text: "Invoker",
+            link: "execution/invoker",
+          },
+        ],
+      },
+      {
+        text: "Authorization",
+        link: "authorization",
+      },
+      {
+        text: "Validation",
+        link: "validation",
+      },
+      {
+        text: "Sanitization",
+        link: "sanitization",
+      },
+    ],
+  }),
 
-    bundler: viteBundler(),
+  base: "/filterable",
+
+  bundler: viteBundler(),
 });

--- a/docs/execution/invoker.md
+++ b/docs/execution/invoker.md
@@ -1,0 +1,151 @@
+# Invoker – Fluent Control Over Query Execution
+
+## Overview
+
+The `Invoker` class in the Filterable package is a smart execution wrapper that allows you to control the lifecycle of your query after applying filters. It is returned by the `Filterable::apply()` method and supports actions **before**, **after**, or **on error** during query execution.
+
+---
+
+## Purpose
+
+`Invoker` wraps the underlying query builder and enables:
+
+- Executing callbacks **before** the query runs.
+- Handling results **after** the query runs.
+- Capturing **errors** and providing fallback logic.
+- Dispatching the query as a Laravel job.
+- Fluent chaining with `when` and `unless` conditions.
+
+---
+
+## Usage Example
+
+```php
+$result = Filterable::apply(User::query())
+    ->beforeExecute(function ($builder) {
+      $builder->where('is_active', true);
+    })
+    ->afterExecute(function (Collection $result) {
+        return $result->filter(fn ($user) => $user->isActive());
+    })
+    ->onError(function ($invoker, $exception) {
+        report($exception);
+        return collect(); // fallback
+    })
+    ->get(); // <-- This will trigger the execution
+```
+
+## Public Methods
+
+`Invoker::init(QueryBuilderInterface $builder)`
+
+Create a new Invoker instance manually.
+
+---
+
+### beforeExecute
+
+`->beforeExecute(Closure $callback): static`
+Register a callback to be called before the query is executed.
+
+**Parameters**:
+
+- `Closure $callback`: Receives the internal query builder.
+
+---
+
+### afterExecute
+
+`->afterExecute(Closure $callback): static`
+Register a callback to process or modify the result after execution.
+
+**Parameters**:
+
+- `Closure $callback`: Receives the result returned by the terminal method.
+
+---
+
+### onError
+
+`->onError(Closure $callback): static`
+Register a callback to handle any exceptions that occur during query execution.
+
+**Parameters**:
+`Closure $callback`: Receives the Invoker and the thrown exception.
+
+---
+
+### when
+
+`->when(bool $condition, callable $callback): static`
+Conditionally apply logic to the Invoker chain.
+
+---
+
+### unless
+
+`->unless(bool $condition, callable $callback): static`
+The inverse of when.
+
+---
+
+### asJob
+
+`->asJob(string $jobClass, array $data = [], ?string $queue = null): mixed`
+Dispatch the query execution as a Laravel job.
+
+**Parameters**:
+
+- `string $jobClass`: The name of the job class to dispatch.
+- `array $data`: Optional additional data.
+- `string|null $queue`: Optional queue name.
+
+---
+
+### When Invoker is Skipped
+
+In some advanced use cases, the `Invoker` wrapper will be **skipped**, and the `apply()` method will return the query builder directly.
+
+This happens in two cases:
+
+1. If the target class implements the `ShouldReturnQueryBuilder` interface:
+
+```php
+<?php
+
+namespace App\Http\Filters;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Foundation\Contracts\ShouldReturnQueryBuilder;
+
+class PostFilter extends Filterable implements ShouldReturnQueryBuilder
+{
+//
+}
+```
+
+2. If you explicitly call the `shouldReturnQueryBuilder()` method before calling a terminal method.
+
+```php
+$filter = Filterable::create()
+    ->shouldReturnQueryBuilder()
+    ->apply(Post::query()) // <- Returns Query builder directly
+```
+
+This is useful when you want to bypass Invoker's control layer and interact with the builder as usual.
+
+---
+
+Notes:
+The job class must accept an `invoker` key in its constructor data.
+
+## Summary
+
+`Invoker` is your **last-mile control layer** before the query is executed. It's ideal for:
+
+- Logging
+- Result transformation
+- Fallbacks
+- Background execution
+
+This gives Filterable a clean and powerful **declarative style**.

--- a/src/Engines/Expression.php
+++ b/src/Engines/Expression.php
@@ -17,6 +17,12 @@ use Kettasoft\Filterable\Exceptions\NotAllowedFieldException;
 class Expression extends Engine
 {
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'expression';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Contracts\Database\Eloquent\Builder $builder
    * @return Builder
@@ -86,5 +92,14 @@ class Expression extends Engine
   public function defaultOperator(): string
   {
     return config('filterable.engines.expression.default_operator', 'eq');
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -42,6 +42,8 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
 
   abstract protected function getAllowedFieldsFromConfig(): array;
 
+  abstract public function getEngineName(): string;
+
   public function getAllowedFields(): array
   {
     return array_merge($this->getAllowedFieldsFromConfig(), $this->context->getAllowedFields());

--- a/src/Engines/Invokeable.php
+++ b/src/Engines/Invokeable.php
@@ -14,6 +14,12 @@ class Invokeable extends Engine
   use ForwardsCalls;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'invokable';
+
+  /**
    * The Eloquent builder instance.
    * @var Builder
    */
@@ -121,5 +127,14 @@ class Invokeable extends Engine
   public function defaultOperator(): string
   {
     return config('filterable.engines.invokable.default_operator', 'eq');
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Ruleset.php
+++ b/src/Engines/Ruleset.php
@@ -15,6 +15,12 @@ class Ruleset extends Engine
   use FieldNormalizer;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'ruleset';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Database\Eloquent\Builder $builder
    * @return Builder
@@ -77,5 +83,14 @@ class Ruleset extends Engine
   public function isStrictFromConfig(): bool
   {
     return config('filterable.engines.ruleset.strict', true);
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Tree.php
+++ b/src/Engines/Tree.php
@@ -20,6 +20,12 @@ class Tree extends Engine
   use FieldNormalizer;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'tree';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Database\Eloquent\Builder $builder
    * @return Builder
@@ -117,5 +123,14 @@ class Tree extends Engine
   public function isStrictFromConfig(): bool
   {
     return config('filterable.engines.tree.strict', true);
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Foundation/Contracts/QueryBuilderInterface.php
+++ b/src/Foundation/Contracts/QueryBuilderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Contracts;
+
+use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @mixin \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
+ */
+interface QueryBuilderInterface extends EloquentBuilder, QueryBuilder {}

--- a/src/Foundation/Contracts/ShouldReturnQueryBuilder.php
+++ b/src/Foundation/Contracts/ShouldReturnQueryBuilder.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Contracts;
+
+interface ShouldReturnQueryBuilder {}

--- a/src/Foundation/Invoker.php
+++ b/src/Foundation/Invoker.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation;
+
+use Closure;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
+
+/**
+ * Class Invoker
+ *
+ * The Invoker class acts as a wrapper around a query builder instance,
+ * providing hooks for before/after execution logic, error handling, and
+ * flexible runtime behavior such as deferred execution via Laravel jobs.
+ * 
+ * @link https://kettasoft.github.io/filterable/execution/invoker
+ */
+class Invoker implements QueryBuilderInterface
+{
+  use ForwardsCalls,
+    HandleFluentReturn;
+
+  /**
+   * Callback to be executed before the query is run.
+   * 
+   * @var Closure|null
+   */
+  protected $beforeCallback;
+
+  /**
+   * Callback to be executed after the query is run.
+   * 
+   * @var Closure|null
+   */
+  protected $afterCallback;
+
+  /**
+   * Callback to be executed in case of error during query execution.
+   * 
+   * @var Closure|null
+   */
+  protected $errorCallback;
+
+  /**
+   * Create a new Invoker instance.
+   *
+   * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|QueryBuilderInterface $builder
+   */
+  public function __construct(protected EloquentBuilder|QueryBuilderInterface $builder) {}
+
+  /**
+   * Instantiate a new Invoker object using a builder.
+   * @param \Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface $builder
+   * @return Invoker
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#public-methods
+   */
+  public static function init(QueryBuilderInterface $builder)
+  {
+    return new self($builder);
+  }
+
+  /**
+   * Execute a callback if the given condition is true.
+   *
+   * @param bool $condition
+   * @param callable $callback
+   * @return static
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#when
+   */
+  public function when(bool $condition, callable $callback): static
+  {
+    if ($condition) {
+      $callback($this);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Execute a callback if the given condition is false.
+   *
+   * @param bool $condition
+   * @param callable $callback
+   * @return static
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#unless
+   */
+  public function unless(bool $condition, callable $callback): static
+  {
+    return $this->when(!$condition, $callback);
+  }
+
+  /**
+   * Set the callback to be called before execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#beforeExecute
+   */
+  public function beforeExecute(Closure $callback): static
+  {
+    $this->beforeCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Set the callback to be called after execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#afterExecute
+   */
+  public function afterExecute(Closure $callback): static
+  {
+    $this->afterCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Set the callback to be called after execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#onError
+   */
+  public function onError(Closure $callback)
+  {
+    $this->errorCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Dispatch the query execution as a Laravel job.
+   *
+   * @param string $jobClass
+   * @param array $jobData
+   * @param string|null $queue
+   * @return mixed
+   *
+   * @throws \InvalidArgumentException
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#asJob
+   */
+  public function asJob(string $jobClass, array $jobData = [], string|null $queue = null): mixed
+  {
+    if (!class_exists($jobClass)) {
+      throw new \InvalidArgumentException("Job class [$jobClass] does not exist.");
+    }
+
+    $job = new $jobClass(array_merge($jobData, [
+      'invoker' => $this,
+    ]));
+
+    if ($queue) {
+      return dispatch($job)->onQueue($queue);
+    }
+
+    return dispatch($job);
+  }
+
+  /**
+   * Handles dynamic calls to the builder, and tracks execution time
+   * for terminal methods only.
+   *
+   * @param string $method
+   * @param array $args
+   * @return mixed
+   */
+  public function __call($method, $args)
+  {
+    if (is_callable($callback = $this->beforeCallback)) {
+      call_user_func($callback, $this->builder);
+    }
+
+    try {
+      $result = $this->handleFluentReturn($method, $args);
+
+      if (is_callable($this->afterCallback)) {
+        return call_user_func($this->afterCallback, $result);
+      }
+
+      return $result;
+    } catch (\Throwable $th) {
+      if (is_callable($callback = $this->errorCallback)) {
+        return call_user_func($callback, $this, $th);
+      }
+
+      throw $th;
+    }
+  }
+}

--- a/src/Foundation/Traits/HandleFluentReturn.php
+++ b/src/Foundation/Traits/HandleFluentReturn.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Traits;
+
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
+
+trait HandleFluentReturn
+{
+  /**
+   * Processes the result of a forwarded call to the builder.
+   *
+   * If the result is an instance of Builder, it updates the internal builder
+   * reference and returns $this for fluent chaining. Otherwise, it returns the result as-is.
+   *
+   * @param mixed $result The result returned from the forwarded call.
+   * @return mixed Returns $this if the result is a Builder, otherwise returns the original result.
+   */
+  protected function handleFluentReturn($method, $args)
+  {
+
+    $result = $this->forwardCallTo($this->builder, $method, $args);
+
+    if ($result instanceof QueryBuilderInterface) {
+      $this->builder = $result;
+      return $this;
+    }
+
+    return $result;
+  }
+}

--- a/src/Support/FilterRegisterator.php
+++ b/src/Support/FilterRegisterator.php
@@ -2,12 +2,13 @@
 
 namespace Kettasoft\Filterable\Support;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Traits\ForwardsCalls;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\App;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Kettasoft\Filterable\Contracts\FilterableContext;
 use Kettasoft\Filterable\Exceptions\FilterIsNotDefinedException;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
 
 class FilterRegisterator
 {
@@ -39,9 +40,9 @@ class FilterRegisterator
   /**
    * Bind the filter instance to model.
    * @throws \Kettasoft\Filterable\Exceptions\FilterIsNotDefinedException
-   * @return \Illuminate\Database\Eloquent\Builder
+   * @return QueryBuilderInterface
    */
-  public function register(): Builder
+  public function register(): QueryBuilderInterface
   {
     if ($this->filter instanceof FilterableContext) {
       return $this->forwardCallTo($this->filter, 'apply', [$this->builder]);

--- a/src/Traits/HasFilterable.php
+++ b/src/Traits/HasFilterable.php
@@ -6,6 +6,7 @@ use Kettasoft\Filterable\Filterable;
 use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Support\FilterRegisterator;
 use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
 
 /**
  * Apply filters dynamically to Eloquent Query.
@@ -20,7 +21,7 @@ trait HasFilterable
    * @param \Kettasoft\Filterable\Filterable|string|null $filter
    * @return \Illuminate\Database\Eloquent\Builder
    */
-  public function scopeFilter(Builder $query, Filterable|string|array|null $filter = null): Builder
+  public function scopeFilter(Builder $query, Filterable|string|array|null $filter = null): QueryBuilderInterface
   {
     return (new FilterRegisterator($query, $filter))->register();
   }

--- a/tests/Unit/Filterable/AutoFilterScopeInjectionTest.php
+++ b/tests/Unit/Filterable/AutoFilterScopeInjectionTest.php
@@ -2,11 +2,11 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Filterable;
-use Kettasoft\Filterable\Providers\AutoRegisterFilterableServiceProvider;
+use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Tests\TestCase;
+use Illuminate\Contracts\Database\Query\Builder;
+use Kettasoft\Filterable\Providers\AutoRegisterFilterableServiceProvider;
 
 class AutoFilterScopeInjectionTest extends TestCase
 {

--- a/tests/Unit/Filterable/FilterAliasesTest.php
+++ b/tests/Unit/Filterable/FilterAliasesTest.php
@@ -2,10 +2,10 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Filterable;
 use Kettasoft\Filterable\Tests\TestCase;
 use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Contracts\Database\Query\Builder;
 use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
 
 class FilterAliasesTest extends TestCase

--- a/tests/Unit/Filterable/FilterableInvokerTest.php
+++ b/tests/Unit/Filterable/FilterableInvokerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Illuminate\Support\Facades\Queue;
+use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Database\Eloquent\Collection;
+use Kettasoft\Filterable\Foundation\Invoker;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+use Kettasoft\Filterable\Tests\Jobs\TestExecuteFilterJob;
+
+class FilterableInvokerTest extends TestCase
+{
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    Post::factory(10)->create([
+      'status' => 'active'
+    ]);
+
+    Post::factory(10)->create([
+      'status' => 'stopped'
+    ]);
+  }
+
+  public function test_it_can_recover_invoker_instance()
+  {
+    $result = Post::filter(new PostFilter);
+
+    $this->assertInstanceOf(Invoker::class, $result);
+  }
+
+  public function test_it_can_invoke_callback_before()
+  {
+
+    $result = Post::filter(new PostFilter);
+
+    $count = $result->beforeExecute(function ($builder) {
+      $builder->where('status', 'active');
+    })->count();
+
+    $this->assertEquals(10, $count);
+  }
+
+  public function test_it_can_invoke_callback_after()
+  {
+
+    /**
+     * @var Invoker
+     */
+    $result = Post::filter(new PostFilter);
+
+    $result = $result->afterExecute(function (Collection $result) {
+      return $result->filter(function ($item) {
+        return $item->id > 10;
+      });
+    })->get();
+
+    $this->assertEquals(10, $result->count());
+  }
+
+  public function test_it_executes_when_callback_if_condition_is_true()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->when(true, function ($instance) use (&$invoked) {
+      $invoked = true;
+      $this->assertInstanceOf(Invoker::class, $instance);
+    });
+
+    $this->assertTrue($invoked, 'Expected the callback to be invoked when condition is true.');
+  }
+
+  public function test_it_does_not_execute_when_callback_if_condition_is_false()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->when(false, function () use (&$invoked) {
+      $invoked = true;
+    });
+
+    $this->assertFalse($invoked, 'Expected the callback NOT to be invoked when condition is false.');
+  }
+
+  public function test_it_executes_unless_callback_if_condition_is_false()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->unless(false, function ($instance) use (&$invoked) {
+      $invoked = true;
+      $this->assertInstanceOf(Invoker::class, $instance);
+    });
+
+    $this->assertTrue($invoked, 'Expected the callback to be invoked when condition is false.');
+  }
+
+  public function test_it_does_not_execute_unless_callback_if_condition_is_true()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->unless(true, function () use (&$invoked) {
+      $invoked = true;
+    });
+
+    $this->assertFalse($invoked, 'Expected the callback NOT to be invoked when condition is true.');
+  }
+
+  public function test_it_dispatches_job_with_invoker_through_asJob()
+  {
+    Queue::fake();
+
+    $invoker = Post::filter(new PostFilter());
+
+    $invoker->asJob(TestExecuteFilterJob::class, ['extra' => 'test']);
+
+    Queue::assertPushed(TestExecuteFilterJob::class, function ($job) use ($invoker) {
+      return $job->invoker === $invoker && $job->extra === 'test';
+    });
+  }
+
+  public function test_it_invoke_callback_on_error()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    /**
+     * @var Invoker
+     */
+    $result = Post::filter(new PostFilter);
+
+    $result->onError(function ($context, $th) {
+      throw new \InvalidArgumentException();
+    });
+
+    $result->whereHas('invalid', 'invalid');
+
+    $result->get();
+  }
+}

--- a/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
+++ b/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
@@ -4,8 +4,8 @@ namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
 use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Tests\TestCase;
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Traits\HasFilterable;
+use Illuminate\Contracts\Database\Query\Builder;
 use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
 use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
 

--- a/tests/Unit/Filterable/ModelToBuilderResolutionTest.php
+++ b/tests/Unit/Filterable/ModelToBuilderResolutionTest.php
@@ -2,10 +2,10 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Filterable;
-use Kettasoft\Filterable\Tests\Models\Post;
 use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class ModelToBuilderResolutionTest extends TestCase
 {


### PR DESCRIPTION
### Summary

This PR introduces the new `Invoker` feature in the Filterable package, providing fluent control over how queries are executed after filters are applied. It also includes a comprehensive documentation page under `execution/invoker`.

### Included in This PR

#### 💡 New Feature
- `Invoker` class that wraps the filtered query builder.
- Supports:
  - `beforeExecute()` – mutate the builder before execution.
  - `afterExecute()` – modify results after execution.
  - `onError()` – handle exceptions and provide fallbacks.
  - `asJob()` – dispatch query execution as a Laravel job.
  - `when()` / `unless()` – conditionally apply logic.

### Benefits

- Enables advanced, customizable query execution logic.
- Makes Filterable more extensible and production-ready.
- Paves the way for future enhancements like `retry`, `timeout`, `pipeline`, and `transactions`.