### PR TITLE
Release: Filterable v2.0.0 with Profiler, Aliases, Auto-Binding & Laravel 12 Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[docker-compose.yml]
+indent_size = 4

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "develop"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "develop"]
 
 permissions:
   contents: read

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "php.version": "8.3"
+  "php.version": "8.4"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.0.0] - 2025-07-29
+
+### Added
+
+-   ✅ **Laravel 9, 10, 11, and 12 support**.
+-   ✅ **Auto Binding** for filter classes via Laravel container.
+-   ✅ **Automatic `filter()` macro registration** for Eloquent models.
+-   ✅ **Filter Aliases** system for mapping short keys to fully qualified filter class names.
+
+### Changed
+
+-   🔧 Refactored internal architecture for better modularity and performance.
+-   ♻️ Service provider responsibilities reorganized for automatic setup and registration.
+
+### Breaking Changes
+
+-   Auto-registration and macro binding have replaced manual trait inclusion.
+-   Custom filter bindings must now follow the new auto-discovery mechanism.
+-   Aliases must be declared in the config if you wish to use them in the query input.

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
   "require": {
     "php": "^8.0",
     "illuminate/database": "^8.0|^9.0|^10.0|^11.0|^12.0",
-    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0"
+    "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+    "opis/closure": "^4.3"
   },
   "require-dev": {
     "mockery/mockery": "^1.3.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   ],
   "autoload": {
     "psr-4": {
-      "Kettasoft\\Filterable\\": "src/"
+      "Kettasoft\\Filterable\\": "src/",
+      "Kettasoft\\Filterable\\Database\\Migrations\\": "database/migrations/"
     },
     "files": [
       "src/Support/helpers.php"

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,12 @@
     "test": "php vendor/bin/phpunit"
   },
   "extra": {
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "laravel": {
+      "providers": [
+        "Kettasoft\\Filterable\\Providers\\FilterableServiceProvider"
+      ]
+    }
   },
   "minimum-stability": "dev",
   "prefer-stable": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cc309fc2f2787106c285285a50df31b",
+    "content-hash": "3c890a4ff69b2b504cdaf6c9da82e857",
     "packages": [
         {
             "name": "brick/math",
@@ -3144,16 +3144,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101"
+                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/9e27aecde8f506ba0fd1d9989620c04a87697101",
-                "reference": "9e27aecde8f506ba0fd1d9989620c04a87697101",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5f360ebc65c55265a74d23d7fe27f957870158a1",
+                "reference": "5f360ebc65c55265a74d23d7fe27f957870158a1",
                 "shasum": ""
             },
             "require": {
@@ -3218,7 +3218,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.3.1"
+                "source": "https://github.com/symfony/console/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3230,11 +3230,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-07-30T17:13:41+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3370,16 +3374,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "35b55b166f6752d6aaf21aa042fc5ed280fce235"
+                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/35b55b166f6752d6aaf21aa042fc5ed280fce235",
-                "reference": "35b55b166f6752d6aaf21aa042fc5ed280fce235",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
+                "reference": "0b31a944fcd8759ae294da4d2808cbc53aebd0c3",
                 "shasum": ""
             },
             "require": {
@@ -3427,7 +3431,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.3.1"
+                "source": "https://github.com/symfony/error-handler/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3439,11 +3443,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-13T07:48:40+00:00"
+            "time": "2025-07-07T08:17:57+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -3603,16 +3611,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.3.0",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d"
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ec2344cf77a48253bbca6939aa3d2477773ea63d",
-                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe",
                 "shasum": ""
             },
             "require": {
@@ -3647,7 +3655,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.3.0"
+                "source": "https://github.com/symfony/finder/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3659,24 +3667,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-30T19:00:26+00:00"
+            "time": "2025-07-15T13:41:35+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "23dd60256610c86a3414575b70c596e5deff6ed9"
+                "reference": "6877c122b3a6cc3695849622720054f6e6fa5fa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/23dd60256610c86a3414575b70c596e5deff6ed9",
-                "reference": "23dd60256610c86a3414575b70c596e5deff6ed9",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6877c122b3a6cc3695849622720054f6e6fa5fa6",
+                "reference": "6877c122b3a6cc3695849622720054f6e6fa5fa6",
                 "shasum": ""
             },
             "require": {
@@ -3726,7 +3738,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.3.1"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3738,24 +3750,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T15:07:14+00:00"
+            "time": "2025-07-10T08:47:49+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "1644879a66e4aa29c36fe33dfa6c54b450ce1831"
+                "reference": "6ecc895559ec0097e221ed2fd5eb44d5fede083c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1644879a66e4aa29c36fe33dfa6c54b450ce1831",
-                "reference": "1644879a66e4aa29c36fe33dfa6c54b450ce1831",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/6ecc895559ec0097e221ed2fd5eb44d5fede083c",
+                "reference": "6ecc895559ec0097e221ed2fd5eb44d5fede083c",
                 "shasum": ""
             },
             "require": {
@@ -3840,7 +3856,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.3.1"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3852,24 +3868,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-28T08:24:55+00:00"
+            "time": "2025-07-31T10:45:04+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "b5db5105b290bdbea5ab27b89c69effcf1cb3368"
+                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/b5db5105b290bdbea5ab27b89c69effcf1cb3368",
-                "reference": "b5db5105b290bdbea5ab27b89c69effcf1cb3368",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
+                "reference": "d43e84d9522345f96ad6283d5dfccc8c1cfc299b",
                 "shasum": ""
             },
             "require": {
@@ -3920,7 +3940,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.3.1"
+                "source": "https://github.com/symfony/mailer/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3932,24 +3952,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-07-15T11:36:08+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.3.0",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9"
+                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9",
-                "reference": "0e7b19b2f399c31df0cdbe5d8cbf53f02f6cfcd9",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/e0a0f859148daf1edf6c60b398eb40bfc96697d1",
+                "reference": "e0a0f859148daf1edf6c60b398eb40bfc96697d1",
                 "shasum": ""
             },
             "require": {
@@ -4004,7 +4028,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.3.0"
+                "source": "https://github.com/symfony/mime/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -4016,11 +4040,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-19T08:51:26+00:00"
+            "time": "2025-07-15T13:41:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4722,16 +4750,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v7.3.0",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "8e213820c5fea844ecea29203d2a308019007c15"
+                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/8e213820c5fea844ecea29203d2a308019007c15",
-                "reference": "8e213820c5fea844ecea29203d2a308019007c15",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
+                "reference": "7614b8ca5fa89b9cd233e21b627bfc5774f586e4",
                 "shasum": ""
             },
             "require": {
@@ -4783,7 +4811,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.3.0"
+                "source": "https://github.com/symfony/routing/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -4795,11 +4823,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-24T20:43:28+00:00"
+            "time": "2025-07-15T11:36:08+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -4886,16 +4918,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v7.3.0",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125"
+                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f3570b8c61ca887a9e2938e85cb6458515d2b125",
-                "reference": "f3570b8c61ca887a9e2938e85cb6458515d2b125",
+                "url": "https://api.github.com/repos/symfony/string/zipball/42f505aff654e62ac7ac2ce21033818297ca89ca",
+                "reference": "42f505aff654e62ac7ac2ce21033818297ca89ca",
                 "shasum": ""
             },
             "require": {
@@ -4953,7 +4985,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.3.0"
+                "source": "https://github.com/symfony/string/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -4965,24 +4997,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-20T20:19:01+00:00"
+            "time": "2025-07-10T08:47:49+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "241d5ac4910d256660238a7ecf250deba4c73063"
+                "reference": "81b48f4daa96272efcce9c7a6c4b58e629df3c90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/241d5ac4910d256660238a7ecf250deba4c73063",
-                "reference": "241d5ac4910d256660238a7ecf250deba4c73063",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/81b48f4daa96272efcce9c7a6c4b58e629df3c90",
+                "reference": "81b48f4daa96272efcce9c7a6c4b58e629df3c90",
                 "shasum": ""
             },
             "require": {
@@ -5049,7 +5085,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.3.1"
+                "source": "https://github.com/symfony/translation/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -5061,11 +5097,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-07-30T17:31:46+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -5221,16 +5261,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42"
+                "reference": "53205bea27450dc5c65377518b3275e126d45e75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
-                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53205bea27450dc5c65377518b3275e126d45e75",
+                "reference": "53205bea27450dc5c65377518b3275e126d45e75",
                 "shasum": ""
             },
             "require": {
@@ -5242,7 +5282,6 @@
                 "symfony/console": "<6.4"
             },
             "require-dev": {
-                "ext-iconv": "*",
                 "symfony/console": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
                 "symfony/process": "^6.4|^7.0",
@@ -5285,7 +5324,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.1"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -5297,11 +5336,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T19:55:54+00:00"
+            "time": "2025-07-29T20:02:46+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -6072,16 +6115,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.3",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
-                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -6120,7 +6163,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -6128,20 +6171,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-05T12:25:42+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.5.0",
+            "version": "v5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
-                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
                 "shasum": ""
             },
             "require": {
@@ -6184,9 +6227,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
             },
-            "time": "2025-05-31T08:24:38+00:00"
+            "time": "2025-07-27T20:03:57+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -8320,16 +8363,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.3.1",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb"
+                "reference": "b8d7d868da9eb0919e99c8830431ea087d6aae30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0c3555045a46ab3cd4cc5a69d161225195230edb",
-                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b8d7d868da9eb0919e99c8830431ea087d6aae30",
+                "reference": "b8d7d868da9eb0919e99c8830431ea087d6aae30",
                 "shasum": ""
             },
             "require": {
@@ -8372,7 +8415,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.1"
+                "source": "https://github.com/symfony/yaml/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -8384,11 +8427,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-03T06:57:57+00:00"
+            "time": "2025-07-10T08:47:49+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c890a4ff69b2b504cdaf6c9da82e857",
+    "content-hash": "3f0286236c8f3cafd03ee8963ef690f0",
     "packages": [
         {
             "name": "brick/math",
@@ -2382,6 +2382,70 @@
                 }
             ],
             "time": "2025-05-08T08:14:37+00:00"
+        },
+        {
+            "name": "opis/closure",
+            "version": "4.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/closure.git",
+                "reference": "9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/closure/zipball/9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df",
+                "reference": "9b6ef5f622b4b29cf98bdc144f2a370c3a40d4df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Opis\\Closure\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "A library that can be used to serialize closures (anonymous functions) and arbitrary data.",
+            "homepage": "https://opis.io/closure",
+            "keywords": [
+                "anonymous functions",
+                "closure",
+                "function",
+                "serializable",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/closure/issues",
+                "source": "https://github.com/opis/closure/tree/4.3.1"
+            },
+            "time": "2025-01-10T20:42:24+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -54,7 +54,7 @@ return [
     | "engines" section below.
     |
     */
-    'default_engine' => 'invokeable',
+    'default_engine' => 'invokable',
 
     /*
     |--------------------------------------------------------------------------
@@ -75,7 +75,7 @@ return [
         | The Invokeable Engine provides a powerful way to dynamically map incomming reuqest parameters to corresponding methods in a filter class.
         |
         */
-        'invokeable' => [
+        'invokable' => [
             /*
             |--------------------------------------------------------------------------
             | Egnore empty values

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -471,4 +471,72 @@ return [
         */
         'fallback_strategy' => 'default',
     ],
+
+    'profiler' => [
+
+        /*
+        |--------------------------------------------------------------------------
+        | Enable or Disable Query Profiler
+        |--------------------------------------------------------------------------
+        |
+        | This option allows you to enable or disable the query profiler system.
+        | You may want to disable it in production or when running background jobs.
+        |
+        */
+        'enabled' => env('FILTERABLE_PROFILER_ENABLED', true),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Log Queries or Store in Database
+        |--------------------------------------------------------------------------
+        |
+        | Determines how query profiling data will be stored.
+        | Supported: "log", "database", "none"
+        |
+        */
+        'store' => env('FILTERABLE_PROFILER_STORE', 'log'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Minimum Execution Time Threshold (ms)
+        |--------------------------------------------------------------------------
+        |
+        | Queries that execute faster than this threshold will not be stored.
+        | This helps avoid logging trivial queries.
+        |
+        */
+        'slow_query_threshold' => env('FILTERABLE_PROFILER_MIN_TIME', 1.0),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Sampling Percentage
+        |--------------------------------------------------------------------------
+        |
+        | To reduce overhead, you can profile only X% of the requests randomly.
+        | For example, 10 means 10% of calls will be stored.
+        |
+        */
+        'sampling' => env('FILTERABLE_PROFILER_SAMPLING', 100),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Database Table Name
+        |--------------------------------------------------------------------------
+        |
+        | If using "database" as a storage method, this is the table where
+        | query profiles will be stored.
+        |
+        */
+        'table' => 'query_profiles',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Log Channel
+        |--------------------------------------------------------------------------
+        |
+        | If using "log" as a storage method, this is the log channel used.
+        |
+        */
+        'log_channel' => env('FILTERABLE_PROFILER_LOG_CHANNEL', 'daily'),
+    ],
 ];

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -1,5 +1,7 @@
 <?php
 
+use Kettasoft\Filterable\Filterable;
+
 return [
     /*
     |--------------------------------------------------------------------------
@@ -43,6 +45,20 @@ return [
     |
     */
     'request_source' => 'query',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Filter Aliases
+    |--------------------------------------------------------------------------
+    |
+    | Define short, human-friendly aliases for your filter classes.
+    | These aliases allow you to reference filters using simple names
+    | when building dynamic or automatic filter logic, instead of full class paths.
+    |
+    */
+    'aliases' => Filterable::aliases([
+        // 'users' => App\Http\Filters\UserFilter::class
+    ]),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/CreateProfilerTable.php
+++ b/database/migrations/CreateProfilerTable.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kettasoft\Filterable\Database\Migrations;
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateProfilerTable extends Migration
+{
+  /**
+   * Run the migrations.
+   *
+   * @return void
+   */
+  public function up()
+  {
+    Schema::create('profiler', function (Blueprint $table) {
+      $table->id();
+      $table->text('query');
+      $table->integer('execution_time');
+      $table->integer('memory_usage');
+      $table->string('status')->default('success'); // 'success' or 'error'
+      $table->text('error_message')->nullable(); // For storing error messages if any
+      $table->string('connection_name')->nullable(); // For multi-connection support
+      $table->string('model_class')->nullable(); // For storing the model class if applicable
+      $table->string('query_type')->nullable(); // For storing the type of query (e.g., 'select', 'insert', 'update', 'delete')
+      $table->string('user_id')->nullable(); // For storing the user ID if applicable
+      $table->string('ip_address')->nullable(); // For storing the IP address of the user executing the query
+      $table->string('session_id')->nullable(); // For storing the session ID if applicable
+      $table->timestamp('executed_at')->useCurrent(); // Timestamp for when the query was executed
+      $table->string('environment')->nullable(); // For storing the environment (e.g., 'production', 'development', 'testing')
+      $table->string('application_version')->nullable(); // For storing the application version if applicable
+      $table->string('query_hash')->nullable(); // For storing a hash of the query for quick lookups
+      $table->string('request_method')->nullable(); // For storing the HTTP request method (e.g., 'GET', 'POST')
+      $table->string('request_uri')->nullable(); // For storing the request URI
+      $table->timestamps();
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   *
+   * @return void
+   */
+  public function down()
+  {
+    Schema::dropIfExists('profiler');
+  }
+}

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -76,6 +76,11 @@ export default defineUserConfig({
                         text: "Header-Driven Filter Mode",
                         link: "features/header-driven-filter-mode",
                     },
+
+                    {
+                        text: "Auto Register Filterable Macro",
+                        link: "features/auto-register-filterable-macro",
+                    },
                     {
                         text: "Filter Aliases",
                         link: "features/aliasing",

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,97 +3,101 @@ import { defineUserConfig } from "vuepress/cli";
 import { viteBundler } from "@vuepress/bundler-vite";
 
 export default defineUserConfig({
-  lang: "en-US",
+    lang: "en-US",
 
-  title: "Filterable",
-  description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
+    title: "Filterable",
+    description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
 
-  plugins: [
-    {
-      name: "@vuepress/plugin-search",
-    },
-  ],
-
-  theme: defaultTheme({
-    repo: "https://github.com/kettasoft/filterable",
-    // logo: "/docs/logo.png",
-
-    colorModeSwitch: true,
-    sidebarDepth: 3,
-    logoAlt: null,
-    logo: null,
-    selectLanguageText: "ar",
-    selectLanguageName: "ar",
-    lastUpdated: true,
-    contributors: true,
-    // contributorsText: "dasdasd",
-
-    navbar: ["/", "/installation"],
-    sidebar: [
-      {
-        text: "Home",
-        link: "/",
-      },
-      {
-        text: "Introduction",
-        link: "/introduction",
-      },
-      {
-        text: "Installation",
-        link: "/installation",
-      },
-      {
-        text: "How It Works",
-        link: "how-it-works",
-      },
-      {
-        text: "Engines",
-        collapsible: true,
-        children: [
-          {
-            text: "Invokable",
-            link: "engines/invokable",
-          },
-          {
-            text: "Tree",
-            link: "engines/tree",
-          },
-          {
-            text: "Ruleset",
-            link: "engines/rule-set",
-          },
-          {
-            text: "Expression",
-            link: "engines/expression",
-          },
-        ],
-      },
-      {
-        text: "Features",
-        collapsible: true,
-        children: [
-          {
-            text: "Header-Driven Filter Mode",
-            link: "features/header-driven-filter-mode",
-          },
-        ],
-      },
-      {
-        text: "Authorization",
-        link: "authorization",
-      },
-      {
-        text: "Validation",
-        link: "validation",
-      },
-      {
-        text: "Sanitization",
-        link: "sanitization",
-      },
+    plugins: [
+        {
+            name: "@vuepress/plugin-search",
+        },
     ],
-  }),
 
-  base: "/filterable",
+    theme: defaultTheme({
+        repo: "https://github.com/kettasoft/filterable",
+        // logo: "/docs/logo.png",
 
-  bundler: viteBundler(),
+        colorModeSwitch: true,
+        sidebarDepth: 3,
+        logoAlt: null,
+        logo: null,
+        selectLanguageText: "ar",
+        selectLanguageName: "ar",
+        lastUpdated: true,
+        contributors: true,
+        // contributorsText: "dasdasd",
+
+        navbar: ["/", "/installation"],
+        sidebar: [
+            {
+                text: "Home",
+                link: "/",
+            },
+            {
+                text: "Introduction",
+                link: "/introduction",
+            },
+            {
+                text: "Installation",
+                link: "/installation",
+            },
+            {
+                text: "How It Works",
+                link: "how-it-works",
+            },
+            {
+                text: "Engines",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Invokable",
+                        link: "engines/invokable",
+                    },
+                    {
+                        text: "Tree",
+                        link: "engines/tree",
+                    },
+                    {
+                        text: "Ruleset",
+                        link: "engines/rule-set",
+                    },
+                    {
+                        text: "Expression",
+                        link: "engines/expression",
+                    },
+                ],
+            },
+            {
+                text: "Features",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Header-Driven Filter Mode",
+                        link: "features/header-driven-filter-mode",
+                    },
+                    {
+                        text: "Filter Aliases",
+                        link: "features/aliasing",
+                    },
+                ],
+            },
+            {
+                text: "Authorization",
+                link: "authorization",
+            },
+            {
+                text: "Validation",
+                link: "validation",
+            },
+            {
+                text: "Sanitization",
+                link: "sanitization",
+            },
+        ],
+    }),
+
+    base: "/filterable",
+
+    bundler: viteBundler(),
 });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,118 +3,128 @@ import { defineUserConfig } from "vuepress/cli";
 import { viteBundler } from "@vuepress/bundler-vite";
 
 export default defineUserConfig({
-    lang: "en-US",
+  lang: "en-US",
 
-    title: "Filterable",
-    description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
+  title: "Filterable",
+  description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
 
-    plugins: [
-        {
-            name: "@vuepress/plugin-search",
-        },
-    ],
+  plugins: [
+    {
+      name: "@vuepress/plugin-search",
+    },
+  ],
 
-    theme: defaultTheme({
-        repo: "https://github.com/kettasoft/filterable",
-        // logo: "/docs/logo.png",
+  theme: defaultTheme({
+    repo: "https://github.com/kettasoft/filterable",
+    // logo: "/docs/logo.png",
 
-        colorModeSwitch: true,
-        sidebarDepth: 3,
-        logoAlt: null,
-        logo: null,
-        selectLanguageText: "ar",
-        selectLanguageName: "ar",
-        lastUpdated: true,
-        contributors: true,
-        // contributorsText: "dasdasd",
+    colorModeSwitch: true,
+    sidebarDepth: 3,
+    logoAlt: null,
+    logo: null,
+    selectLanguageText: "ar",
+    selectLanguageName: "ar",
+    lastUpdated: true,
+    contributors: true,
+    // contributorsText: "dasdasd",
 
-        navbar: ["/", "/installation"],
-        sidebar: [
-            {
-                text: "Home",
-                link: "/",
-            },
-            {
-                text: "Introduction",
-                link: "/introduction",
-            },
-            {
-                text: "Installation",
-                link: "/installation",
-            },
-            {
-                text: "How It Works",
-                link: "how-it-works",
-            },
-            {
-                text: "Engines",
-                collapsible: true,
-                children: [
-                    {
-                        text: "Invokable",
-                        link: "engines/invokable",
-                    },
-                    {
-                        text: "Tree",
-                        link: "engines/tree",
-                    },
-                    {
-                        text: "Ruleset",
-                        link: "engines/rule-set",
-                    },
-                    {
-                        text: "Expression",
-                        link: "engines/expression",
-                    },
-                ],
-            },
-            {
-                text: "Features",
-                collapsible: true,
-                children: [
-                    {
-                        text: "Header-Driven Filter Mode",
-                        link: "features/header-driven-filter-mode",
-                    },
-
-                    {
-                        text: "Auto Register Filterable Macro",
-                        link: "features/auto-register-filterable-macro",
-                    },
-                    {
-                        text: "Conditional Logic",
-                        link: "features/conditional-logic-with-when",
-                    },
-                    {
-                        text: "Filter Aliases",
-                        link: "features/aliasing",
-                    },
-                    {
-                        text: "Through callbacks",
-                        link: "features/through",
-                    },
-                    {
-                        text: "Auto Binding",
-                        link: "features/auto-binding",
-                    },
-                ],
-            },
-            {
-                text: "Authorization",
-                link: "authorization",
-            },
-            {
-                text: "Validation",
-                link: "validation",
-            },
-            {
-                text: "Sanitization",
-                link: "sanitization",
-            },
+    navbar: ["/", "/installation"],
+    sidebar: [
+      {
+        text: "Home",
+        link: "/",
+      },
+      {
+        text: "Introduction",
+        link: "/introduction",
+      },
+      {
+        text: "Installation",
+        link: "/installation",
+      },
+      {
+        text: "How It Works",
+        link: "how-it-works",
+      },
+      {
+        text: "Engines",
+        collapsible: true,
+        children: [
+          {
+            text: "Invokable",
+            link: "engines/invokable",
+          },
+          {
+            text: "Tree",
+            link: "engines/tree",
+          },
+          {
+            text: "Ruleset",
+            link: "engines/rule-set",
+          },
+          {
+            text: "Expression",
+            link: "engines/expression",
+          },
         ],
-    }),
+      },
+      {
+        text: "Features",
+        collapsible: true,
+        children: [
+          {
+            text: "Header-Driven Filter Mode",
+            link: "features/header-driven-filter-mode",
+          },
 
-    base: "/filterable",
+          {
+            text: "Auto Register Filterable Macro",
+            link: "features/auto-register-filterable-macro",
+          },
+          {
+            text: "Conditional Logic",
+            link: "features/conditional-logic-with-when",
+          },
+          {
+            text: "Filter Aliases",
+            link: "features/aliasing",
+          },
+          {
+            text: "Through callbacks",
+            link: "features/through",
+          },
+          {
+            text: "Auto Binding",
+            link: "features/auto-binding",
+          },
+        ],
+      },
+      {
+        text: "Execution",
+        collapsible: true,
+        children: [
+          {
+            text: "Invoker",
+            link: "execution/invoker",
+          },
+        ],
+      },
+      {
+        text: "Authorization",
+        link: "authorization",
+      },
+      {
+        text: "Validation",
+        link: "validation",
+      },
+      {
+        text: "Sanitization",
+        link: "sanitization",
+      },
+    ],
+  }),
 
-    bundler: viteBundler(),
+  base: "/filterable",
+
+  bundler: viteBundler(),
 });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,128 +3,132 @@ import { defineUserConfig } from "vuepress/cli";
 import { viteBundler } from "@vuepress/bundler-vite";
 
 export default defineUserConfig({
-  lang: "en-US",
+    lang: "en-US",
 
-  title: "Filterable",
-  description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
+    title: "Filterable",
+    description: "Kettasoft Filterable - Powerful Eloquent Filtering Package",
 
-  plugins: [
-    {
-      name: "@vuepress/plugin-search",
-    },
-  ],
-
-  theme: defaultTheme({
-    repo: "https://github.com/kettasoft/filterable",
-    // logo: "/docs/logo.png",
-
-    colorModeSwitch: true,
-    sidebarDepth: 3,
-    logoAlt: null,
-    logo: null,
-    selectLanguageText: "ar",
-    selectLanguageName: "ar",
-    lastUpdated: true,
-    contributors: true,
-    // contributorsText: "dasdasd",
-
-    navbar: ["/", "/installation"],
-    sidebar: [
-      {
-        text: "Home",
-        link: "/",
-      },
-      {
-        text: "Introduction",
-        link: "/introduction",
-      },
-      {
-        text: "Installation",
-        link: "/installation",
-      },
-      {
-        text: "How It Works",
-        link: "how-it-works",
-      },
-      {
-        text: "Engines",
-        collapsible: true,
-        children: [
-          {
-            text: "Invokable",
-            link: "engines/invokable",
-          },
-          {
-            text: "Tree",
-            link: "engines/tree",
-          },
-          {
-            text: "Ruleset",
-            link: "engines/rule-set",
-          },
-          {
-            text: "Expression",
-            link: "engines/expression",
-          },
-        ],
-      },
-      {
-        text: "Features",
-        collapsible: true,
-        children: [
-          {
-            text: "Header-Driven Filter Mode",
-            link: "features/header-driven-filter-mode",
-          },
-
-          {
-            text: "Auto Register Filterable Macro",
-            link: "features/auto-register-filterable-macro",
-          },
-          {
-            text: "Conditional Logic",
-            link: "features/conditional-logic-with-when",
-          },
-          {
-            text: "Filter Aliases",
-            link: "features/aliasing",
-          },
-          {
-            text: "Through callbacks",
-            link: "features/through",
-          },
-          {
-            text: "Auto Binding",
-            link: "features/auto-binding",
-          },
-        ],
-      },
-      {
-        text: "Execution",
-        collapsible: true,
-        children: [
-          {
-            text: "Invoker",
-            link: "execution/invoker",
-          },
-        ],
-      },
-      {
-        text: "Authorization",
-        link: "authorization",
-      },
-      {
-        text: "Validation",
-        link: "validation",
-      },
-      {
-        text: "Sanitization",
-        link: "sanitization",
-      },
+    plugins: [
+        {
+            name: "@vuepress/plugin-search",
+        },
     ],
-  }),
 
-  base: "/filterable",
+    theme: defaultTheme({
+        repo: "https://github.com/kettasoft/filterable",
+        // logo: "/docs/logo.png",
 
-  bundler: viteBundler(),
+        colorModeSwitch: true,
+        sidebarDepth: 3,
+        logoAlt: null,
+        logo: null,
+        selectLanguageText: "ar",
+        selectLanguageName: "ar",
+        lastUpdated: true,
+        contributors: true,
+        // contributorsText: "dasdasd",
+
+        navbar: ["/", "/installation"],
+        sidebar: [
+            {
+                text: "Home",
+                link: "/",
+            },
+            {
+                text: "Introduction",
+                link: "/introduction",
+            },
+            {
+                text: "Installation",
+                link: "/installation",
+            },
+            {
+                text: "How It Works",
+                link: "how-it-works",
+            },
+            {
+                text: "Engines",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Invokable",
+                        link: "engines/invokable",
+                    },
+                    {
+                        text: "Tree",
+                        link: "engines/tree",
+                    },
+                    {
+                        text: "Ruleset",
+                        link: "engines/rule-set",
+                    },
+                    {
+                        text: "Expression",
+                        link: "engines/expression",
+                    },
+                ],
+            },
+            {
+                text: "Features",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Header-Driven Filter Mode",
+                        link: "features/header-driven-filter-mode",
+                    },
+
+                    {
+                        text: "Auto Register Filterable Macro",
+                        link: "features/auto-register-filterable-macro",
+                    },
+                    {
+                        text: "Conditional Logic",
+                        link: "features/conditional-logic-with-when",
+                    },
+                    {
+                        text: "Filter Aliases",
+                        link: "features/aliasing",
+                    },
+                    {
+                        text: "Through callbacks",
+                        link: "features/through",
+                    },
+                    {
+                        text: "Auto Binding",
+                        link: "features/auto-binding",
+                    },
+                ],
+            },
+            {
+                text: "Execution",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Invoker",
+                        link: "execution/invoker",
+                    },
+                ],
+            },
+            {
+                text: "Profiler",
+                link: "profiler",
+            },
+            {
+                text: "Authorization",
+                link: "authorization",
+            },
+            {
+                text: "Validation",
+                link: "validation",
+            },
+            {
+                text: "Sanitization",
+                link: "sanitization",
+            },
+        ],
+    }),
+
+    base: "/filterable",
+
+    bundler: viteBundler(),
 });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -85,6 +85,10 @@ export default defineUserConfig({
                         text: "Filter Aliases",
                         link: "features/aliasing",
                     },
+                    {
+                        text: "Auto Binding",
+                        link: "features/auto-binding",
+                    },
                 ],
             },
             {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -82,8 +82,16 @@ export default defineUserConfig({
                         link: "features/auto-register-filterable-macro",
                     },
                     {
+                        text: "Conditional Logic",
+                        link: "features/conditional-logic-with-when",
+                    },
+                    {
                         text: "Filter Aliases",
                         link: "features/aliasing",
+                    },
+                    {
+                        text: "Through callbacks",
+                        link: "features/through",
                     },
                     {
                         text: "Auto Binding",

--- a/docs/execution/invoker.md
+++ b/docs/execution/invoker.md
@@ -1,0 +1,151 @@
+# Invoker – Fluent Control Over Query Execution
+
+## Overview
+
+The `Invoker` class in the Filterable package is a smart execution wrapper that allows you to control the lifecycle of your query after applying filters. It is returned by the `Filterable::apply()` method and supports actions **before**, **after**, or **on error** during query execution.
+
+---
+
+## Purpose
+
+`Invoker` wraps the underlying query builder and enables:
+
+- Executing callbacks **before** the query runs.
+- Handling results **after** the query runs.
+- Capturing **errors** and providing fallback logic.
+- Dispatching the query as a Laravel job.
+- Fluent chaining with `when` and `unless` conditions.
+
+---
+
+## Usage Example
+
+```php
+$result = Filterable::apply(User::query())
+    ->beforeExecute(function ($builder) {
+      $builder->where('is_active', true);
+    })
+    ->afterExecute(function (Collection $result) {
+        return $result->filter(fn ($user) => $user->isActive());
+    })
+    ->onError(function ($invoker, $exception) {
+        report($exception);
+        return collect(); // fallback
+    })
+    ->get(); // <-- This will trigger the execution
+```
+
+## Public Methods
+
+`Invoker::init(QueryBuilderInterface $builder)`
+
+Create a new Invoker instance manually.
+
+---
+
+### beforeExecute
+
+`->beforeExecute(Closure $callback): static`
+Register a callback to be called before the query is executed.
+
+**Parameters**:
+
+- `Closure $callback`: Receives the internal query builder.
+
+---
+
+### afterExecute
+
+`->afterExecute(Closure $callback): static`
+Register a callback to process or modify the result after execution.
+
+**Parameters**:
+
+- `Closure $callback`: Receives the result returned by the terminal method.
+
+---
+
+### onError
+
+`->onError(Closure $callback): static`
+Register a callback to handle any exceptions that occur during query execution.
+
+**Parameters**:
+`Closure $callback`: Receives the Invoker and the thrown exception.
+
+---
+
+### when
+
+`->when(bool $condition, callable $callback): static`
+Conditionally apply logic to the Invoker chain.
+
+---
+
+### unless
+
+`->unless(bool $condition, callable $callback): static`
+The inverse of when.
+
+---
+
+### asJob
+
+`->asJob(string $jobClass, array $data = [], ?string $queue = null): mixed`
+Dispatch the query execution as a Laravel job.
+
+**Parameters**:
+
+- `string $jobClass`: The name of the job class to dispatch.
+- `array $data`: Optional additional data.
+- `string|null $queue`: Optional queue name.
+
+---
+
+### When Invoker is Skipped
+
+In some advanced use cases, the `Invoker` wrapper will be **skipped**, and the `apply()` method will return the query builder directly.
+
+This happens in two cases:
+
+1. If the target class implements the `ShouldReturnQueryBuilder` interface:
+
+```php
+<?php
+
+namespace App\Http\Filters;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Foundation\Contracts\ShouldReturnQueryBuilder;
+
+class PostFilter extends Filterable implements ShouldReturnQueryBuilder
+{
+//
+}
+```
+
+2. If you explicitly call the `shouldReturnQueryBuilder()` method before calling a terminal method.
+
+```php
+$filter = Filterable::create()
+    ->shouldReturnQueryBuilder()
+    ->apply(Post::query()) // <- Returns Query builder directly
+```
+
+This is useful when you want to bypass Invoker's control layer and interact with the builder as usual.
+
+---
+
+Notes:
+The job class must accept an `invoker` key in its constructor data.
+
+## Summary
+
+`Invoker` is your **last-mile control layer** before the query is executed. It's ideal for:
+
+- Logging
+- Result transformation
+- Fallbacks
+- Background execution
+
+This gives Filterable a clean and powerful **declarative style**.

--- a/docs/features/aliasing.md
+++ b/docs/features/aliasing.md
@@ -1,0 +1,35 @@
+# Filter Aliases
+
+## Overview
+
+Filter Aliases allow you to assign short or contextual names to filter classes, enabling reusable logic with cleaner naming in requests or controller logic.
+
+### ⚙️ Setup
+
+In your `config/filterable.php`, define aliases like so:
+
+```php
+'aliases' => Filterable::aliases([
+    'active_users' => App\Filters\ActiveUserFilter::class,
+    'vip' => App\Filters\VipUserFilter::class,
+]),
+```
+
+### 🧪 Usage
+
+```php
+User::filter('active_users')->get();
+```
+
+The appropriate filter classes will be resolved and applied automatically.
+
+### 💡 Benefits
+
+-   Cleaner API interface.
+-   Reusability of filter classes across contexts.
+-   Improves frontend-backend consistency.
+
+### ⚠️ Notes
+
+-   Alias names must be unique.
+-   If an alias and real filter share the same key, the real filter will be prioritized.

--- a/docs/features/auto-binding.md
+++ b/docs/features/auto-binding.md
@@ -1,0 +1,41 @@
+# Auto Binding Filter Class in Models
+
+You can now define a default filter class directly inside your model by setting the `$filterable` property.
+
+This allows the `filter()` method to automatically resolve the corresponding filter class without having to explicitly pass it.
+
+## ✨ Usage
+
+Inside your Eloquent model, define a `$filterable` property and assign the class name of your filter:
+
+```php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Kettasoft\Filterable\Traits\HasFilterable;
+
+class User extends Model
+{
+    use HasFilterable;
+    protected $filterable = \App\Http\Filters\UserFilter::class;
+}
+```
+
+Then, when calling the filter() method, you no longer need to provide the filter class manually:
+
+```php
+$users = User::filter()->get();
+```
+
+The package will automatically resolve and use the UserFilter class defined in the model.
+
+## 🧠 Notes
+
+-   If no $filterable is set on the model, you will still need to pass the filter class manually to filter().
+-   This feature works nicely with your existing filter engines and aliases.
+
+## ✅ Benefits
+
+-   Cleaner, shorter code.
+-   Better encapsulation.
+-   Each model manages its own filtering logic.

--- a/docs/features/auto-register-filterable-macro.md
+++ b/docs/features/auto-register-filterable-macro.md
@@ -1,0 +1,51 @@
+# Auto Register Filterable Macro
+
+## Overview
+
+By default, to use the **`filter()`** macro on Eloquent models, you must use the HasFilterable trait in each model. However, if you prefer to automatically register the **`filter()`** method on all Eloquent builders without modifying individual models, you can use the **`AutoRegisterFilterableServiceProvider`**.
+
+### ✅ How to Use
+
+1. Register the Service Provider
+   Open your `config/app.php` and manually register the service provider:
+
+```php
+'providers' => [
+    // Other service providers...
+    Kettasoft\Filterable\Providers\AutoRegisterFilterableServiceProvider::class,
+],
+```
+
+2. Remove the Trait (Optional)
+   You can now remove the HasFilterable trait from your Eloquent models:
+
+```php
+class User extends Model
+{
+    // No need for HasFilterable trait
+}
+```
+
+3. Use the Filter Method
+   Use the `filter()` macro like this, even without using the trait:
+
+```php
+$users = User::filter(UserFilter::class)->get();
+```
+
+Or if the model defines the $filterable property:
+
+```php
+class User extends Model
+{
+    protected $filterable = \App\Filters\UserFilter::class;
+}
+
+$users = User::filter()->get();
+```
+
+### ⚠️ When Should You Use It?
+
+-   ✅ You want zero setup per model.
+-   ✅ You prefer centralized control over all query filtering.
+-   ❌ You want explicit opt-in per model using HasFilterable.

--- a/docs/features/conditional-logic-with-when.md
+++ b/docs/features/conditional-logic-with-when.md
@@ -1,0 +1,54 @@
+# Conditional Logic with **`when`**
+
+## Overview
+
+The `when()` method allows you to conditionally modify the instance based on a boolean expression.
+Instead of writing verbose conditionals, `when()` helps you write expressive, chainable, and concise logic to update your filter configuration.
+Unlike immutability patterns, this method modifies the current instance directly and returns $this, making it perfect for method chaining.
+
+### ✨ Usage
+
+```php
+$filter = Filterable::create()
+    ->when($isAdmin, function (Filterable $filter) {
+    $filter->setAllowedFields(['email', 'role']);
+});
+```
+
+In this example, the setAllowedFields() call is only executed if $isAdmin is true.
+
+### 🔁 Nesting
+
+```php
+Filterable::create()->when(true, function ($filter) {
+    $filter->setAllowedFields(['name']);
+
+    $filter->when(true, function ($filter) {
+        $filter->setAllowedFields(['email', 'phone']);
+
+        $filter->when(true, fn($f) => $f->setAllowedFields(['address']));
+    });
+});
+```
+
+### 🔬 Behavior
+
+If $condition is true → callback is invoked with the current instance.
+
+If $condition is false → nothing happens.
+
+In both cases, the original instance is returned.
+
+### 💡 Benefits
+
+-   ✨ Cleaner Code:
+    Eliminates the need for verbose if conditions. Just chain your logic fluently using when().
+-   🧠 Improved Readability:
+    The code reads naturally, e.g.,
+    “When the condition is true, apply this logic.”
+-   🧪 Easier Testing:
+    Testing conditional filter logic becomes straightforward and expressive.
+-   🔁 Supports Nesting:
+    Allows deeply nested conditional logic while keeping the syntax clean and expressive.
+-   🔗 Chainable Design:
+    when() returns the same instance, enabling seamless method chaining without breaking flow.

--- a/docs/features/through.md
+++ b/docs/features/through.md
@@ -1,0 +1,49 @@
+# Apply Custom Query Callbacks using through()
+
+## Overview
+
+The `through()` method allows you to apply an array of custom query callbacks to the Eloquent builder instance within the `Filterable` class.
+
+This gives you a powerful way to manipulate queries using closures (similar to pipelines), before or after applying filters — enabling advanced use cases such as chaining global conditions, joins, or even reordering logic externally.
+
+### 🧪 Usage
+
+```php
+use Kettasoft\Filterable\Filterable;
+use App\Models\Post;
+
+$filter = Filterable::create()->setBuilder(Post::query());
+
+$results = $filter->through([
+    fn ($builder) => $builder->where('status', 'published'),
+    fn ($builder) => $builder->orderByDesc('created_at'),
+]);
+
+$posts = $results->apply()->get();
+```
+
+You can also chain with other Filterable methods:
+
+```php
+$results = Filterable::create()
+    ->setBuilder(Post::query())
+    ->through([
+        fn ($builder) => $builder->where('is_active', true),
+    ])
+    ->apply();
+```
+
+### ⚠️ Notes
+
+-   Every item in the array passed to through() must be a valid callable.
+-   If a non-callable value is passed, an InvalidArgumentException will be thrown.
+-   Callbacks receive the query builder as the only argument and must return the modified builder.
+-   This method is chainable and returns the Filterable instance.
+
+### 💡 Benefits
+
+-   🔄 Adds a flexible, composable way to extend queries externally.
+-   🧪 Great for injecting reusable query logic without modifying filters.
+-   🚫 Prevents tight coupling between filter logic and query logic.
+-   ✅ Compatible with both eager and late filter application (apply()).
+-   🧱 Clean separation of filtering rules and additional query logic.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Filter Aliases
+    |--------------------------------------------------------------------------
+    |
+    | Define short, human-friendly aliases for your filter classes.
+    | These aliases allow you to reference filters using simple names
+    | when building dynamic or automatic filter logic, instead of full class paths.
+    |
+    */
+    'aliases' => Filterable::aliases([
+        // 'users' => App\Http\Filters\UserFilter::class
+    ]),
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Filter Engine
     |--------------------------------------------------------------------------
     |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ return [
     | "engines" section below.
     |
     */
-    'default_engine' => 'invokeable',
+    'default_engine' => 'invokable',
 
     /*
     |--------------------------------------------------------------------------
@@ -109,7 +109,7 @@ return [
         | The Invokeable Engine provides a powerful way to dynamically map incomming reuqest parameters to corresponding methods in a filter class.
         |
         */
-        'invokeable' => [
+        'invokable' => [
             /*
             |--------------------------------------------------------------------------
             | Egnore empty values

--- a/docs/profiler.md
+++ b/docs/profiler.md
@@ -1,0 +1,85 @@
+# Filterable Profiler
+
+## Overview
+
+The **Filterable Profiler** is a lightweight query observer that runs **only for queries executed via the Filterable layer.**
+
+## ⚙️ Configuration
+
+```php
+'profiler' => [
+  /*
+  |--------------------------------------------------------------------------
+  | Enable or Disable Query Profiler
+  |--------------------------------------------------------------------------
+  | Turn the profiler on or off globally.
+  | Example: FILTERABLE_PROFILER_ENABLED=false
+  */
+  'enabled' => env('FILTERABLE_PROFILER_ENABLED', true),
+
+  /*
+  |--------------------------------------------------------------------------
+  | Storage Method
+  |--------------------------------------------------------------------------
+  | Determines how query profiling data will be stored.
+  | Options: "log", "database", "none"
+  */
+  'store' => env('FILTERABLE_PROFILER_STORE', 'log'),
+
+  /*
+  |--------------------------------------------------------------------------
+  | Minimum Execution Time (ms)
+  |--------------------------------------------------------------------------
+  | Only queries slower than this threshold will be stored.
+  */
+  'slow_query_threshold' => env('FILTERABLE_PROFILER_MIN_TIME', 1.0),
+
+  /*
+  |--------------------------------------------------------------------------
+  | Sampling Percentage
+  |--------------------------------------------------------------------------
+  | To reduce overhead, profile only X% of requests.
+  | Example: FILTERABLE_PROFILER_SAMPLING=10 (10% of calls)
+  */
+  'sampling' => env('FILTERABLE_PROFILER_SAMPLING', 100),
+
+  /*
+  |--------------------------------------------------------------------------
+  | Database Table
+  |--------------------------------------------------------------------------
+  | Table name for storing query profiles when using "database".
+  */
+  'table' => 'query_profiles',
+
+  /*
+  |--------------------------------------------------------------------------
+  | Log Channel
+  |--------------------------------------------------------------------------
+  | Log channel to use when "log" storage is enabled.
+  */
+  'log_channel' => env('FILTERABLE_PROFILER_LOG_CHANNEL', 'daily'),
+],
+```
+
+## 🛠 How it Works
+
+-   The profiler **only monitors queries triggered via the Filterable system**.
+-   At the end of the request, it stores the captured data according to the configured `store` method (`log` or `database`).
+-   Overhead can be controlled via `sampling` and `slow_query_threshold`.
+
+## 📌 Example Usage
+
+Enable the profiler in .env:
+
+```dotenv
+FILTERABLE_PROFILER_ENABLED=true
+FILTERABLE_PROFILER_STORE=log
+FILTERABLE_PROFILER_MIN_TIME=5
+FILTERABLE_PROFILER_SAMPLING=50
+```
+
+Result:
+
+-   50% of requests are sampled.
+-   Only queries slower than 5ms are logged.
+-   Data is stored in the log channel.

--- a/src/Engines/Expression.php
+++ b/src/Engines/Expression.php
@@ -17,6 +17,12 @@ use Kettasoft\Filterable\Exceptions\NotAllowedFieldException;
 class Expression extends Engine
 {
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'expression';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Contracts\Database\Eloquent\Builder $builder
    * @return Builder
@@ -86,5 +92,14 @@ class Expression extends Engine
   public function defaultOperator(): string
   {
     return config('filterable.engines.expression.default_operator', 'eq');
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Factory/EngineManager.php
+++ b/src/Engines/Factory/EngineManager.php
@@ -18,7 +18,7 @@ class EngineManager
     'tree' => Tree::class,
     'ruleset' => Ruleset::class,
     'expression' => Expression::class,
-    'invokeable' => Invokeable::class
+    'invokable' => Invokeable::class
   ];
 
   /**

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -42,6 +42,8 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
 
   abstract protected function getAllowedFieldsFromConfig(): array;
 
+  abstract public function getEngineName(): string;
+
   public function getAllowedFields(): array
   {
     return array_merge($this->getAllowedFieldsFromConfig(), $this->context->getAllowedFields());

--- a/src/Engines/Invokeable.php
+++ b/src/Engines/Invokeable.php
@@ -31,7 +31,7 @@ class Invokeable extends Engine
     foreach ($this->context->getFilterAttributes() as $filter) {
       $value = $this->context->getRequest()->get($filter);
 
-      if (($this->context->hasIgnoredEmptyValues() || config('filterable.engines.invokeable.ignore_empty_values')) && !$value) {
+      if (($this->context->hasIgnoredEmptyValues() || config('filterable.engines.invokable.ignore_empty_values')) && !$value) {
         continue;
       }
 
@@ -101,17 +101,17 @@ class Invokeable extends Engine
    */
   protected function getAllowedFieldsFromConfig(): array
   {
-    return config('filterable.engines.invokeable.allowed_fields', []);
+    return config('filterable.engines.invokable.allowed_fields', []);
   }
 
   public function getOperatorsFromConfig(): array
   {
-    return config('filterable.engines.invokeable.allowed_operators', []);
+    return config('filterable.engines.invokable.allowed_operators', []);
   }
 
   public function isStrictFromConfig(): bool
   {
-    return config('filterable.engines.invokeable.strict', true);
+    return config('filterable.engines.invokable.strict', true);
   }
 
   /**
@@ -120,6 +120,6 @@ class Invokeable extends Engine
    */
   public function defaultOperator(): string
   {
-    return config('filterable.engines.invokeable.default_operator', 'eq');
+    return config('filterable.engines.invokable.default_operator', 'eq');
   }
 }

--- a/src/Engines/Invokeable.php
+++ b/src/Engines/Invokeable.php
@@ -14,6 +14,12 @@ class Invokeable extends Engine
   use ForwardsCalls;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'invokable';
+
+  /**
    * The Eloquent builder instance.
    * @var Builder
    */
@@ -121,5 +127,14 @@ class Invokeable extends Engine
   public function defaultOperator(): string
   {
     return config('filterable.engines.invokable.default_operator', 'eq');
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Ruleset.php
+++ b/src/Engines/Ruleset.php
@@ -15,6 +15,12 @@ class Ruleset extends Engine
   use FieldNormalizer;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'ruleset';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Database\Eloquent\Builder $builder
    * @return Builder
@@ -77,5 +83,14 @@ class Ruleset extends Engine
   public function isStrictFromConfig(): bool
   {
     return config('filterable.engines.ruleset.strict', true);
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Engines/Tree.php
+++ b/src/Engines/Tree.php
@@ -20,6 +20,12 @@ class Tree extends Engine
   use FieldNormalizer;
 
   /**
+   * Engine name.
+   * @var string
+   */
+  protected $name = 'tree';
+
+  /**
    * Apply filters to the query.
    * @param \Illuminate\Database\Eloquent\Builder $builder
    * @return Builder
@@ -117,5 +123,14 @@ class Tree extends Engine
   public function isStrictFromConfig(): bool
   {
     return config('filterable.engines.tree.strict', true);
+  }
+
+  /**
+   * Get engine name.
+   * @return string
+   */
+  public function getEngineName(): string
+  {
+    return $this->name;
   }
 }

--- a/src/Exceptions/FilterClassNotResolvedException.php
+++ b/src/Exceptions/FilterClassNotResolvedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+class FilterClassNotResolvedException extends \InvalidArgumentException
+{
+  public function __construct(string $model)
+  {
+    parent::__construct("Could not resolve a filter class for model [{$model}]. Please either define a \$filterable property to the model or pass the filter class manually to the filter() method.");
+  }
+}

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Kettasoft\Filterable\Foundation\Resources;
 use Kettasoft\Filterable\Contracts\Validatable;
 use Kettasoft\Filterable\Contracts\Authorizable;
@@ -25,6 +26,7 @@ use Kettasoft\Filterable\Traits\InteractsWithRelationsFiltering;
 use Kettasoft\Filterable\Traits\InteractsWithFilterAuthorization;
 use Kettasoft\Filterable\HttpIntegration\HeaderDrivenEngineSelector;
 use Kettasoft\Filterable\Exceptions\RequestSourceIsNotSupportedException;
+use Kettasoft\Filterable\Foundation\Bags\Bag;
 
 class Filterable implements FilterableContext, Authorizable, Validatable
 {
@@ -120,6 +122,12 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   protected $model;
 
   /**
+   * Aliases of filter class
+   * @var array
+   */
+  protected static Collection $aliases;
+
+  /**
    * The Sanitizer instance.
    * @var Sanitizer
    */
@@ -190,6 +198,17 @@ class Filterable implements FilterableContext, Authorizable, Validatable
   public function filter(Builder|null $builder = null): Builder
   {
     return $this->apply($builder);
+  }
+
+  /**
+   * Get all aliases.
+   * @return Collection
+   */
+  public static function aliases(array $aliases)
+  {
+    self::$aliases = collect($aliases);
+
+    return self::$aliases;
   }
 
   /**

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\Database\Eloquent\Builder;
-use Kettasoft\Filterable\Tests\Models\Post;
 use Kettasoft\Filterable\Foundation\Resources;
 use Kettasoft\Filterable\Contracts\Validatable;
 use Kettasoft\Filterable\Contracts\Authorizable;

--- a/src/Foundation/Bags/Bag.php
+++ b/src/Foundation/Bags/Bag.php
@@ -97,6 +97,16 @@ abstract class Bag implements Countable, Arrayable, ArrayAccess, IteratorAggrega
   }
 
   /**
+   * Merge the items.
+   * @param array $items
+   * @return void
+   */
+  public function merge(array $items)
+  {
+    $this->items = array_merge($this->items, $items);
+  }
+
+  /**
    * Remove an item by key
    * @param TKey $key
    * @return void

--- a/src/Foundation/Contracts/HasDynamicCalls.php
+++ b/src/Foundation/Contracts/HasDynamicCalls.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Contracts;
+
+/**
+ * Interface for classes that support dynamic method calls.
+ *
+ * @package Kettasoft\Filterable\Foundation\Contracts
+ */
+interface HasDynamicCalls
+{
+  /**
+   * Handle dynamic method calls.
+   *
+   * @param string $method
+   * @param array $args
+   * @return mixed
+   */
+  public function __call($method, $args);
+}

--- a/src/Foundation/Contracts/QueryBuilderInterface.php
+++ b/src/Foundation/Contracts/QueryBuilderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Contracts;
+
+use Illuminate\Contracts\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Contracts\Database\Query\Builder as QueryBuilder;
+
+/**
+ * @mixin \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder
+ */
+interface QueryBuilderInterface extends EloquentBuilder, QueryBuilder {}

--- a/src/Foundation/Contracts/ShouldReturnQueryBuilder.php
+++ b/src/Foundation/Contracts/ShouldReturnQueryBuilder.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Contracts;
+
+interface ShouldReturnQueryBuilder {}

--- a/src/Foundation/Invoker.php
+++ b/src/Foundation/Invoker.php
@@ -3,10 +3,16 @@
 namespace Kettasoft\Filterable\Foundation;
 
 use Closure;
+use Serializable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\App;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
 use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
+
+use function Opis\Closure\{serialize, unserialize};
 
 /**
  * Class Invoker
@@ -17,7 +23,7 @@ use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
  * 
  * @link https://kettasoft.github.io/filterable/execution/invoker
  */
-class Invoker implements QueryBuilderInterface
+class Invoker implements QueryBuilderInterface, Serializable
 {
   use ForwardsCalls,
     HandleFluentReturn;
@@ -48,7 +54,7 @@ class Invoker implements QueryBuilderInterface
    *
    * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|QueryBuilderInterface $builder
    */
-  public function __construct(protected EloquentBuilder|QueryBuilderInterface $builder) {}
+  public function __construct(protected EloquentBuilder|Builder|QueryBuilderInterface $builder) {}
 
   /**
    * Instantiate a new Invoker object using a builder.
@@ -134,6 +140,16 @@ class Invoker implements QueryBuilderInterface
   }
 
   /**
+   * Get the underlying query builder instance.
+   *
+   * @return Builder|EloquentBuilder|QueryBuilderInterface
+   */
+  public function getBuilder(): EloquentBuilder|Builder|QueryBuilderInterface
+  {
+    return $this->builder;
+  }
+
+  /**
    * Dispatch the query execution as a Laravel job.
    *
    * @param string $jobClass
@@ -159,6 +175,42 @@ class Invoker implements QueryBuilderInterface
     }
 
     return dispatch($job);
+  }
+
+  /**
+   * Serialize the Invoker instance.
+   *
+   * @return string
+   */
+  public function serialize(): string
+  {
+    return serialize([
+      'builder_sql' => $this->builder->toSql(),
+      'builder_bindings' => $this->builder->getBindings(),
+      'beforeCallback' => $this->beforeCallback ? serialize($this->beforeCallback) : null,
+      'afterCallback' => $this->afterCallback ? serialize($this->afterCallback) : null,
+      'errorCallback' => $this->errorCallback ? serialize($this->errorCallback) : null
+    ]);
+  }
+
+  /**
+   * Unserialize the Invoker instance.
+   *
+   * @param string $data
+   * @return void
+   */
+  public function unserialize($data): void
+  {
+    $unserialized = unserialize($data);
+    $connection = App::make('db')->connection();
+
+    $this->builder = $connection->table(DB::raw("({$unserialized['builder_sql']}) as t"));
+
+    $this->builder->setBindings($unserialized['builder_bindings']);
+
+    $this->beforeCallback = $unserialized['beforeCallback'];
+    $this->afterCallback = $unserialized['afterCallback'];
+    $this->errorCallback = $unserialized['errorCallback'];
   }
 
   /**

--- a/src/Foundation/Invoker.php
+++ b/src/Foundation/Invoker.php
@@ -6,7 +6,7 @@ use Closure;
 use Serializable;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\App;
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Kettasoft\Filterable\Foundation\Profiler\Profiler;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
@@ -54,9 +54,9 @@ class Invoker implements QueryBuilderInterface, Serializable, HasDynamicCalls
   /**
    * Create a new Invoker instance.
    *
-   * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|QueryBuilderInterface $builder
+   * @param QueryBuilder|EloquentBuilder|QueryBuilderInterface $builder
    */
-  public function __construct(protected EloquentBuilder|QueryBuilderInterface $builder)
+  public function __construct(protected QueryBuilder|EloquentBuilder|QueryBuilderInterface $builder)
   {
     if (config('filterable.profiler.enabled', false)) {
       app(Profiler::class)->start();

--- a/src/Foundation/Invoker.php
+++ b/src/Foundation/Invoker.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation;
+
+use Closure;
+use Illuminate\Support\Traits\ForwardsCalls;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
+
+/**
+ * Class Invoker
+ *
+ * The Invoker class acts as a wrapper around a query builder instance,
+ * providing hooks for before/after execution logic, error handling, and
+ * flexible runtime behavior such as deferred execution via Laravel jobs.
+ * 
+ * @link https://kettasoft.github.io/filterable/execution/invoker
+ */
+class Invoker implements QueryBuilderInterface
+{
+  use ForwardsCalls,
+    HandleFluentReturn;
+
+  /**
+   * Callback to be executed before the query is run.
+   * 
+   * @var Closure|null
+   */
+  protected $beforeCallback;
+
+  /**
+   * Callback to be executed after the query is run.
+   * 
+   * @var Closure|null
+   */
+  protected $afterCallback;
+
+  /**
+   * Callback to be executed in case of error during query execution.
+   * 
+   * @var Closure|null
+   */
+  protected $errorCallback;
+
+  /**
+   * Create a new Invoker instance.
+   *
+   * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|QueryBuilderInterface $builder
+   */
+  public function __construct(protected EloquentBuilder|QueryBuilderInterface $builder) {}
+
+  /**
+   * Instantiate a new Invoker object using a builder.
+   * @param \Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface $builder
+   * @return Invoker
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#public-methods
+   */
+  public static function init(QueryBuilderInterface $builder)
+  {
+    return new self($builder);
+  }
+
+  /**
+   * Execute a callback if the given condition is true.
+   *
+   * @param bool $condition
+   * @param callable $callback
+   * @return static
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#when
+   */
+  public function when(bool $condition, callable $callback): static
+  {
+    if ($condition) {
+      $callback($this);
+    }
+
+    return $this;
+  }
+
+  /**
+   * Execute a callback if the given condition is false.
+   *
+   * @param bool $condition
+   * @param callable $callback
+   * @return static
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#unless
+   */
+  public function unless(bool $condition, callable $callback): static
+  {
+    return $this->when(!$condition, $callback);
+  }
+
+  /**
+   * Set the callback to be called before execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#beforeExecute
+   */
+  public function beforeExecute(Closure $callback): static
+  {
+    $this->beforeCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Set the callback to be called after execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#afterExecute
+   */
+  public function afterExecute(Closure $callback): static
+  {
+    $this->afterCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Set the callback to be called after execution.
+   *
+   * @param Closure $callback
+   * @return $this
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#onError
+   */
+  public function onError(Closure $callback)
+  {
+    $this->errorCallback = $callback;
+
+    return $this;
+  }
+
+  /**
+   * Dispatch the query execution as a Laravel job.
+   *
+   * @param string $jobClass
+   * @param array $jobData
+   * @param string|null $queue
+   * @return mixed
+   *
+   * @throws \InvalidArgumentException
+   * @link https://kettasoft.github.io/filterable/execution/invoker.html#asJob
+   */
+  public function asJob(string $jobClass, array $jobData = [], string|null $queue = null): mixed
+  {
+    if (!class_exists($jobClass)) {
+      throw new \InvalidArgumentException("Job class [$jobClass] does not exist.");
+    }
+
+    $job = new $jobClass(array_merge($jobData, [
+      'invoker' => $this,
+    ]));
+
+    if ($queue) {
+      return dispatch($job)->onQueue($queue);
+    }
+
+    return dispatch($job);
+  }
+
+  /**
+   * Handles dynamic calls to the builder, and tracks execution time
+   * for terminal methods only.
+   *
+   * @param string $method
+   * @param array $args
+   * @return mixed
+   */
+  public function __call($method, $args)
+  {
+    if (is_callable($callback = $this->beforeCallback)) {
+      call_user_func($callback, $this->builder);
+    }
+
+    try {
+      $result = $this->handleFluentReturn($method, $args);
+
+      if (is_callable($this->afterCallback)) {
+        return call_user_func($this->afterCallback, $result);
+      }
+
+      return $result;
+    } catch (\Throwable $th) {
+      if (is_callable($callback = $this->errorCallback)) {
+        return call_user_func($callback, $this, $th);
+      }
+
+      throw $th;
+    }
+  }
+}

--- a/src/Foundation/Invoker.php
+++ b/src/Foundation/Invoker.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\App;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Kettasoft\Filterable\Foundation\Profiler\Profiler;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Kettasoft\Filterable\Foundation\Contracts\HasDynamicCalls;
 use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
 use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
 
@@ -23,7 +25,7 @@ use function Opis\Closure\{serialize, unserialize};
  * 
  * @link https://kettasoft.github.io/filterable/execution/invoker
  */
-class Invoker implements QueryBuilderInterface, Serializable
+class Invoker implements QueryBuilderInterface, Serializable, HasDynamicCalls
 {
   use ForwardsCalls,
     HandleFluentReturn;
@@ -54,7 +56,12 @@ class Invoker implements QueryBuilderInterface, Serializable
    *
    * @param \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder|QueryBuilderInterface $builder
    */
-  public function __construct(protected EloquentBuilder|Builder|QueryBuilderInterface $builder) {}
+  public function __construct(protected EloquentBuilder|QueryBuilderInterface $builder)
+  {
+    if (config('filterable.profiler.enabled', false)) {
+      app(Profiler::class)->start();
+    }
+  }
 
   /**
    * Instantiate a new Invoker object using a builder.

--- a/src/Foundation/Profiler/Contracts/ProfilerStorageContract.php
+++ b/src/Foundation/Profiler/Contracts/ProfilerStorageContract.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler\Contracts;
+
+/**
+ * Interface for Profiler Storage.
+ *
+ * This interface defines the methods required for storing.
+ */
+interface ProfilerStorageContract
+{
+  /**
+   * Store the profiler data.
+   *
+   * @param array $data
+   * @return void
+   */
+  public function store(mixed $data): void;
+}

--- a/src/Foundation/Profiler/Events/ProfilerEventDispatcher.php
+++ b/src/Foundation/Profiler/Events/ProfilerEventDispatcher.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler\Events;
+
+class ProfilerEventDispatcher
+{
+  /**
+   * @var array<string, callable[]>
+   */
+  protected array $listeners = [];
+
+  /**
+   * Event name for slow queries.
+   * 
+   * @var string
+   */
+  public const SLOW_QUERY_EVENT_NAME = 'onSlowQuery';
+
+  /**
+   * Event name for duplicate queries.
+   * 
+   * @var string
+   */
+  public const DUBLICATE_QUERY_EVENT_NAME = 'onDuplicateQuery';
+
+  /**
+   * Register an event listener.
+   *
+   * @param string   $event
+   * @param callable $listener
+   * @return void
+   */
+  public function listen(string $event, callable $listener): void
+  {
+    $this->listeners[$event][] = $listener;
+  }
+
+  /**
+   * Dispatch an event.
+   *
+   * @param string $event
+   * @param mixed  $payload
+   * @return void
+   */
+  public function dispatch(string $event, mixed $payload = null): void
+  {
+    foreach ($this->listeners[$event] ?? [] as $listener) {
+      $listener($payload);
+    }
+  }
+
+  /**
+   * Flush all listeners.
+   * 
+   * @return void
+   */
+  public function flush(): void
+  {
+    $this->listeners = [];
+  }
+}

--- a/src/Foundation/Profiler/Profiler.php
+++ b/src/Foundation/Profiler/Profiler.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Application;
+use Kettasoft\Filterable\Foundation\Profiler\Events\ProfilerEventDispatcher;
+use Kettasoft\Filterable\Foundation\Profiler\Contracts\ProfilerStorageContract;
+use Kettasoft\Filterable\Foundation\Profiler\Traits\HasProfilerEventDispatcher;
+
+/**
+ * Profiler class for collecting and analyzing database queries.
+ *
+ * This class listens to database query events and collects information
+ * about executed queries, including SQL, bindings, execution time, and
+ * provides methods to retrieve statistics about the queries.
+ *
+ * @package Kettasoft\Filterable\Foundation\Profiler
+ */
+class Profiler
+{
+  use HasProfilerEventDispatcher;
+
+  /**
+   * Array to hold collected queries.
+   * 
+   * @var array<int, array{sql: string, time: float, bindings: array}>
+   */
+  protected array $queries = [];
+
+  /**
+   * The Laravel application instance.
+   *
+   * @var \Illuminate\Foundation\Application
+   */
+  protected Application $app;
+
+  /**
+   * The current HTTP request instance.
+   *
+   * @var \Illuminate\Http\Request
+   */
+  protected $request;
+
+  /**
+   * Create a new Profiler instance.
+   *
+   * @param ProfilerStorageContract $storage Storage implementation for profiler data.
+   */
+  public function __construct(protected ProfilerStorageContract $storage, protected Builder $builder)
+  {
+    $this->app = app();
+    $this->request = app('request');
+  }
+
+  /**
+   * Start the profiler by listening to database query events.
+   * 
+   * @return void
+   */
+  public function start()
+  {
+    DB::listen(fn(QueryExecuted $query) => $this->addQuery($query));
+  }
+
+  /**
+   * Add a query to the profiler's collection.
+   *
+   * @param QueryExecuted $query
+   * @return void
+   */
+  protected function addQuery(QueryExecuted $query): void
+  {
+    $queryData = [
+      'sql' => $query->sql,
+      'bindings' => $query->bindings,
+      'time' => $query->time,
+    ];
+
+    $this->queries[] = $queryData;
+
+    if ($query->time > config('filterable.profiler.slow_query_threshold', 100)) {
+      $this->dispatch(ProfilerEventDispatcher::SLOW_QUERY_EVENT_NAME, $queryData);
+    }
+
+    // check for duplicate query
+    $duplicates = $this->getDuplicates();
+    foreach ($duplicates as $dup) {
+      if ($dup['sql'] === $query->sql) {
+        $this->dispatch(ProfilerEventDispatcher::DUBLICATE_QUERY_EVENT_NAME, $dup);
+        break;
+      }
+    }
+  }
+
+  /**
+   * Get all collected queries.
+   *
+   * @return array<int, array{sql: string, time: float, bindings: array}>
+   */
+  public function getQueries(): array
+  {
+    return $this->queries;
+  }
+
+  /**
+   * Get duplicated queries (same SQL executed multiple times).
+   *
+   * @return array<int, array{sql: string, count: int, total_time: float}>
+   */
+  public function getDuplicates(): array
+  {
+    $counts = [];
+
+    foreach ($this->queries as $query) {
+      $key = md5($query['sql']);
+      $counts[$key]['sql'] = $query['sql'];
+      $counts[$key]['count'] = ($counts[$key]['count'] ?? 0) + 1;
+      $counts[$key]['total_time'] = ($counts[$key]['total_time'] ?? 0) + $query['time'];
+    }
+
+    return array_values(array_filter($counts, fn($q) => $q['count'] > 1));
+  }
+
+  /**
+   * Get only slow queries over a certain threshold.
+   *
+   * @param float $threshold
+   * @return array<int, array{sql: string, time: float}>
+   */
+  public function getSlowQueries(float $threshold = 100): array
+  {
+    return array_filter($this->queries, fn($q) => $q['time'] > $threshold);
+  }
+
+  /**
+   * Export profiler report as structured array.
+   *
+   * @return array<string, mixed>
+   */
+  public function toExportArray(): array
+  {
+    return [
+      'duplicates' => $this->getDuplicates(),
+      'slow_queries' => $this->getSlowQueries(),
+      'queries' => $this->queries,
+      'total_queries' => count($this->queries),
+      'total_time' => array_sum(array_column($this->queries, 'time')),
+      'total_memory' => memory_get_usage(true),
+      'connection_name' => $this->builder->getConnection()->getDatabaseName(),
+      'executed_at' => now()->toDateTimeString(),
+      'model_class' => $this->builder->getModel() ? get_class($this->builder->getModel()) : null,
+      'request_method' => $this->request->method(),
+      'request_uri' => $this->request->getRequestUri(),
+      'request_query' => $this->request->query(),
+      'request_body' => $this->request->all()
+    ];
+  }
+
+  /**
+   * Destructor to store profiler data when the object is destroyed.
+   * 
+   * @return void
+   */
+  public function __destruct()
+  {
+    $this->storage->store($this->toExportArray());
+  }
+}

--- a/src/Foundation/Profiler/Storage/DatabaseProfilerStorage.php
+++ b/src/Foundation/Profiler/Storage/DatabaseProfilerStorage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler\Storage;
+
+use Illuminate\Support\Facades\DB;
+use Kettasoft\Filterable\Foundation\Profiler\Contracts\ProfilerStorageContract;
+
+class DatabaseProfilerStorage implements ProfilerStorageContract
+{
+  /**
+   * Store the profiler data.
+   *
+   * @param array $data
+   * @return void
+   */
+  public function store(mixed $data): void
+  {
+    DB::table('users')->insert($data);
+  }
+}

--- a/src/Foundation/Profiler/Storage/FileProfilerStorage.php
+++ b/src/Foundation/Profiler/Storage/FileProfilerStorage.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler\Storage;
+
+use Kettasoft\Filterable\Foundation\Profiler\Contracts\ProfilerStorageContract;
+
+class FileProfilerStorage implements ProfilerStorageContract
+{
+  /**
+   * Store the profiler data.
+   *
+   * @param array $data
+   * @return void
+   */
+  public function store(mixed $data): void
+  {
+    $data = array_merge($data, [
+      // Additional data can be added here if needed
+    ]);
+
+    try {
+      $filePath = storage_path('logs/filterable-profiler.log');
+      file_put_contents($filePath, json_encode($data) . PHP_EOL, FILE_APPEND);
+    } catch (\Exception $e) {
+      // Handle any exceptions that may occur during file writing
+      error_log('Profiler storage error: ' . $e->getMessage());
+    }
+  }
+}

--- a/src/Foundation/Profiler/Traits/HasProfilerEventDispatcher.php
+++ b/src/Foundation/Profiler/Traits/HasProfilerEventDispatcher.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Profiler\Traits;
+
+use Kettasoft\Filterable\Foundation\Profiler\Events\ProfilerEventDispatcher;
+
+trait HasProfilerEventDispatcher
+{
+  /**
+   * @var ProfilerEventDispatcher
+   */
+  protected static ?ProfilerEventDispatcher $dispatcher = null;
+
+  /**
+   * Get the current ProfilerEventDispatcher instance.
+   *
+   * @return ProfilerEventDispatcher
+   */
+  public static function dispatcher(): ProfilerEventDispatcher
+  {
+    if (! static::$dispatcher) {
+      static::$dispatcher = new ProfilerEventDispatcher();
+    }
+
+    return static::$dispatcher;
+  }
+
+  /**
+   * Register an event listener (static API).
+   *
+   * @param string   $event
+   * @param callable $callback
+   * @return void
+   */
+  public static function listen(string $event, callable $callback): void
+  {
+    static::dispatcher()->listen($event, $callback);
+  }
+
+  /**
+   * Dispatch an event (used internally).
+   *
+   * @param string $event
+   * @param mixed  $payload
+   * @return void
+   */
+  protected function dispatch(string $event, mixed $payload = null): void
+  {
+    static::dispatcher()->dispatch($event, $payload);
+  }
+}

--- a/src/Foundation/Traits/HandleFluentReturn.php
+++ b/src/Foundation/Traits/HandleFluentReturn.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Traits;
+
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
+
+trait HandleFluentReturn
+{
+  /**
+   * Processes the result of a forwarded call to the builder.
+   *
+   * If the result is an instance of Builder, it updates the internal builder
+   * reference and returns $this for fluent chaining. Otherwise, it returns the result as-is.
+   *
+   * @param mixed $result The result returned from the forwarded call.
+   * @return mixed Returns $this if the result is a Builder, otherwise returns the original result.
+   */
+  protected function handleFluentReturn($method, $args)
+  {
+
+    $result = $this->forwardCallTo($this->builder, $method, $args);
+
+    if ($result instanceof QueryBuilderInterface) {
+      $this->builder = $result;
+      return $this;
+    }
+
+    return $result;
+  }
+}

--- a/src/Providers/AutoRegisterFilterableServiceProvider.php
+++ b/src/Providers/AutoRegisterFilterableServiceProvider.php
@@ -16,7 +16,7 @@ class AutoRegisterFilterableServiceProvider extends ServiceProvider
    */
   public function boot()
   {
-    Builder::macro('filter', function (FilterableContext|string $filter) {
+    Builder::macro('filter', function (FilterableContext|string|null $filter = null) {
       /** @var Builder */
       $builder = $this;
 

--- a/src/Providers/AutoRegisterFilterableServiceProvider.php
+++ b/src/Providers/AutoRegisterFilterableServiceProvider.php
@@ -16,7 +16,7 @@ class AutoRegisterFilterableServiceProvider extends ServiceProvider
    */
   public function boot()
   {
-    Builder::macro('filter', function (FilterableContext $filter) {
+    Builder::macro('filter', function (FilterableContext|string $filter) {
       /** @var Builder */
       $builder = $this;
 

--- a/src/Support/FilterRegisterator.php
+++ b/src/Support/FilterRegisterator.php
@@ -2,12 +2,13 @@
 
 namespace Kettasoft\Filterable\Support;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Traits\ForwardsCalls;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\App;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Traits\ForwardsCalls;
 use Kettasoft\Filterable\Contracts\FilterableContext;
 use Kettasoft\Filterable\Exceptions\FilterIsNotDefinedException;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
 
 class FilterRegisterator
 {
@@ -39,9 +40,9 @@ class FilterRegisterator
   /**
    * Bind the filter instance to model.
    * @throws \Kettasoft\Filterable\Exceptions\FilterIsNotDefinedException
-   * @return \Illuminate\Database\Eloquent\Builder
+   * @return QueryBuilderInterface
    */
-  public function register(): Builder
+  public function register(): QueryBuilderInterface
   {
     if ($this->filter instanceof FilterableContext) {
       return $this->forwardCallTo($this->filter, 'apply', [$this->builder]);

--- a/src/Support/FilterRegisterator.php
+++ b/src/Support/FilterRegisterator.php
@@ -30,7 +30,7 @@ class FilterRegisterator
    * @param \Illuminate\Database\Eloquent\Builder $builder
    * @param mixed $filter
    */
-  public function __construct(Builder $builder, $filter)
+  public function __construct(Builder $builder, $filter = null)
   {
     $this->builder = $builder;
     $this->filter = $filter;
@@ -48,6 +48,12 @@ class FilterRegisterator
     }
 
     if (is_string($this->filter) && $filter = config('filterable.aliases')->get($this->filter)) {
+      $filter = App::make($filter);
+
+      return $this->forwardCallTo($filter, 'apply', [$this->builder]);
+    }
+
+    if ($this->filter === null && $filter = $this->getModel()->getFilterable()) {
       $filter = App::make($filter);
 
       return $this->forwardCallTo($filter, 'apply', [$this->builder]);

--- a/src/Support/FilterRegisterator.php
+++ b/src/Support/FilterRegisterator.php
@@ -5,6 +5,7 @@ namespace Kettasoft\Filterable\Support;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\App;
 use Kettasoft\Filterable\Contracts\FilterableContext;
 use Kettasoft\Filterable\Exceptions\FilterIsNotDefinedException;
 
@@ -20,7 +21,7 @@ class FilterRegisterator
 
   /**
    * Filterable instance.
-   * @var FilterableContext
+   * @var FilterableContext|string
    */
   protected $filter;
 
@@ -44,6 +45,12 @@ class FilterRegisterator
   {
     if ($this->filter instanceof FilterableContext) {
       return $this->forwardCallTo($this->filter, 'apply', [$this->builder]);
+    }
+
+    if (is_string($this->filter) && $filter = config('filterable.aliases')->get($this->filter)) {
+      $filter = App::make($filter);
+
+      return $this->forwardCallTo($filter, 'apply', [$this->builder]);
     }
 
     throw new FilterIsNotDefinedException($this->filter);

--- a/src/Traits/HasFilterable.php
+++ b/src/Traits/HasFilterable.php
@@ -6,6 +6,7 @@ use Kettasoft\Filterable\Filterable;
 use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Support\FilterRegisterator;
 use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
+use Kettasoft\Filterable\Foundation\Contracts\QueryBuilderInterface;
 
 /**
  * Apply filters dynamically to Eloquent Query.
@@ -20,7 +21,7 @@ trait HasFilterable
    * @param \Kettasoft\Filterable\Filterable|string|null $filter
    * @return \Illuminate\Database\Eloquent\Builder
    */
-  public function scopeFilter(Builder $query, Filterable|string|array|null $filter = null): Builder
+  public function scopeFilter(Builder $query, Filterable|string|array|null $filter = null): QueryBuilderInterface
   {
     return (new FilterRegisterator($query, $filter))->register();
   }

--- a/src/Traits/HasFilterable.php
+++ b/src/Traits/HasFilterable.php
@@ -5,6 +5,7 @@ namespace Kettasoft\Filterable\Traits;
 use Kettasoft\Filterable\Filterable;
 use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Support\FilterRegisterator;
+use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
 
 /**
  * Apply filters dynamically to Eloquent Query.
@@ -22,6 +23,19 @@ trait HasFilterable
   public function scopeFilter(Builder $query, Filterable|string|array|null $filter = null): Builder
   {
     return (new FilterRegisterator($query, $filter))->register();
+  }
+
+  /**
+   * Get defined filterable class from model.
+   * @throws \Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException
+   */
+  public function getFilterable()
+  {
+    if (! property_exists($this, 'filterable')) {
+      throw new FilterClassNotResolvedException(get_class($this));
+    }
+
+    return $this->filterable;
   }
 
   /**

--- a/tests/Feature/Invoker/InvokerSerializationTest.php
+++ b/tests/Feature/Invoker/InvokerSerializationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Feature\Invoker;
+
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class InvokerSerializationTest extends TestCase
+{
+  public function test_it_can_be_serialized_and_unserialized()
+  {
+    $builder = Post::query();
+    $invoker = new \Kettasoft\Filterable\Foundation\Invoker($builder);
+
+    // Set some callbacks
+    $invoker->beforeExecute(function () {
+      return 'before';
+    });
+    $invoker->afterExecute(function () {
+      return 'after';
+    });
+    $invoker->onError(function () {
+      return 'error';
+    });
+
+    // Serialize the invoker
+    $serialized = serialize($invoker);
+
+    // Unserialize the invoker
+    $unserializedInvoker = unserialize($serialized);
+
+    // Assert that the unserialized object is an instance of Invoker
+    $this->assertInstanceOf(\Kettasoft\Filterable\Foundation\Invoker::class, $unserializedInvoker);
+  }
+}

--- a/tests/Feature/Profiler/FilterProfilerTest.php
+++ b/tests/Feature/Profiler/FilterProfilerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Feature\Profiler;
+
+use Illuminate\Support\Facades\DB;
+use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Tag;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Database\Events\QueryExecuted;
+use Kettasoft\Filterable\Foundation\Profiler\Profiler;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+
+class FilterProfilerTest extends TestCase
+{
+  public function test_it_triggers_slow_query_event()
+  {
+    $triggered = false;
+
+    Profiler::listen('onSlowQuery', function ($query) use (&$triggered) {
+      $this->assertArrayHasKey('sql', $query);
+      $this->assertArrayHasKey('time', $query);
+      $triggered = true;
+    });
+
+    $profiler = app(Profiler::class);
+    $profiler->start();
+
+    // Simulate a slow query manually
+    $event = new QueryExecuted('select 1', [], 150, DB::connection());
+    $this->invokeMethod($profiler, 'addQuery', [$event]);
+
+    $this->assertTrue($triggered, 'Slow query event was not triggered');
+  }
+
+  public function test_it_triggers_duplicate_query_event()
+  {
+    $triggered = false;
+
+    app(Profiler::class)->dispatcher()->listen('onDuplicateQuery', function ($dup) use (&$triggered) {
+      $this->assertEquals('select 1', $dup['sql']);
+      $this->assertEquals(2, $dup['count']);
+      $triggered = true;
+    });
+
+    $profiler = app(Profiler::class);
+    $profiler->start();
+
+    $event1 = new QueryExecuted('select 1', [], 5, DB::connection());
+    $event2 = new QueryExecuted('select 1', [], 7, DB::connection());
+
+    $this->invokeMethod($profiler, 'addQuery', [$event1]);
+    $this->invokeMethod($profiler, 'addQuery', [$event2]);
+
+    $this->assertTrue($triggered, 'Duplicate query event was not triggered');
+  }
+
+
+  protected function invokeMethod(&$object, $methodName, array $parameters = [])
+  {
+    $reflection = new \ReflectionClass(get_class($object));
+    $method = $reflection->getMethod($methodName);
+    $method->setAccessible(true);
+
+    return $method->invokeArgs($object, $parameters);
+  }
+}

--- a/tests/Http/Filters/PostFilter.php
+++ b/tests/Http/Filters/PostFilter.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Http\Filters;
+
+use Kettasoft\Filterable\Filterable;
+
+class PostFilter extends Filterable
+{
+  //
+}

--- a/tests/Jobs/TestExecuteFilterJob.php
+++ b/tests/Jobs/TestExecuteFilterJob.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use YourPackage\Filterable\Invoker;
+
+class TestExecuteFilterJob implements ShouldQueue
+{
+  use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+  public $invoker;
+  public $extra;
+
+  public function __construct(array $data)
+  {
+    $this->invoker = $data['invoker'];
+    $this->extra = $data['extra'] ?? null;
+  }
+
+  public function handle()
+  {
+    //
+  }
+}

--- a/tests/Unit/Engines/EngineManagerTest.php
+++ b/tests/Unit/Engines/EngineManagerTest.php
@@ -48,7 +48,7 @@ class EngineManagerTest extends TestCase
    */
   public function it_can_create_invokeablke_engine_from_engine_manager()
   {
-    $engine = EngineManager::generate('invokeable', new Filterable());
+    $engine = EngineManager::generate('invokable', new Filterable());
 
     $this->assertInstanceOf(Invokeable::class, $engine);
   }

--- a/tests/Unit/Filterable/AutoFilterScopeInjectionTest.php
+++ b/tests/Unit/Filterable/AutoFilterScopeInjectionTest.php
@@ -2,11 +2,11 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Filterable;
-use Kettasoft\Filterable\Providers\AutoRegisterFilterableServiceProvider;
+use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Tests\TestCase;
+use Illuminate\Contracts\Database\Query\Builder;
+use Kettasoft\Filterable\Providers\AutoRegisterFilterableServiceProvider;
 
 class AutoFilterScopeInjectionTest extends TestCase
 {

--- a/tests/Unit/Filterable/CanUseEngineFromFilterableTest.php
+++ b/tests/Unit/Filterable/CanUseEngineFromFilterableTest.php
@@ -22,12 +22,12 @@ class CanUseEngineFromFilterableTest extends TestCase
     $this->assertInstanceOf(Ruleset::class, $filterable->getEngin());
   }
   /**
-   * It can filterable class use invokeable engine instance
+   * It can filterable class use invokable engine instance
    * @test
    */
-  public function it_can_filterable_class_use_invokeable_engine_instance()
+  public function it_can_filterable_class_use_invokable_engine_instance()
   {
-    $filterable = Filterable::create()->useEngin('invokeable');
+    $filterable = Filterable::create()->useEngin('invokable');
 
     $this->assertInstanceOf(Invokeable::class, $filterable->getEngin());
   }

--- a/tests/Unit/Filterable/FilterAliasesTest.php
+++ b/tests/Unit/Filterable/FilterAliasesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Illuminate\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+
+class FilterAliasesTest extends TestCase
+{
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    config()->set('filterable.aliases', collect([
+      'posts' => PostFilter::class
+    ]));
+  }
+  public function test_it_can_use_alias_filter_name()
+  {
+    $this->assertInstanceOf(Builder::class, Post::filter('posts'));
+  }
+}

--- a/tests/Unit/Filterable/FilterAliasesTest.php
+++ b/tests/Unit/Filterable/FilterAliasesTest.php
@@ -2,10 +2,10 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Filterable;
 use Kettasoft\Filterable\Tests\TestCase;
 use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Contracts\Database\Query\Builder;
 use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
 
 class FilterAliasesTest extends TestCase

--- a/tests/Unit/Filterable/FilterableInvokerTest.php
+++ b/tests/Unit/Filterable/FilterableInvokerTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Illuminate\Support\Facades\Queue;
+use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Database\Eloquent\Collection;
+use Kettasoft\Filterable\Foundation\Invoker;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+use Kettasoft\Filterable\Tests\Jobs\TestExecuteFilterJob;
+
+class FilterableInvokerTest extends TestCase
+{
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    Post::factory(10)->create([
+      'status' => 'active'
+    ]);
+
+    Post::factory(10)->create([
+      'status' => 'stopped'
+    ]);
+  }
+
+  public function test_it_can_recover_invoker_instance()
+  {
+    $result = Post::filter(new PostFilter);
+
+    $this->assertInstanceOf(Invoker::class, $result);
+  }
+
+  public function test_it_can_invoke_callback_before()
+  {
+
+    $result = Post::filter(new PostFilter);
+
+    $count = $result->beforeExecute(function ($builder) {
+      $builder->where('status', 'active');
+    })->count();
+
+    $this->assertEquals(10, $count);
+  }
+
+  public function test_it_can_invoke_callback_after()
+  {
+
+    /**
+     * @var Invoker
+     */
+    $result = Post::filter(new PostFilter);
+
+    $result = $result->afterExecute(function (Collection $result) {
+      return $result->filter(function ($item) {
+        return $item->id > 10;
+      });
+    })->get();
+
+    $this->assertEquals(10, $result->count());
+  }
+
+  public function test_it_executes_when_callback_if_condition_is_true()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->when(true, function ($instance) use (&$invoked) {
+      $invoked = true;
+      $this->assertInstanceOf(Invoker::class, $instance);
+    });
+
+    $this->assertTrue($invoked, 'Expected the callback to be invoked when condition is true.');
+  }
+
+  public function test_it_does_not_execute_when_callback_if_condition_is_false()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->when(false, function () use (&$invoked) {
+      $invoked = true;
+    });
+
+    $this->assertFalse($invoked, 'Expected the callback NOT to be invoked when condition is false.');
+  }
+
+  public function test_it_executes_unless_callback_if_condition_is_false()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->unless(false, function ($instance) use (&$invoked) {
+      $invoked = true;
+      $this->assertInstanceOf(Invoker::class, $instance);
+    });
+
+    $this->assertTrue($invoked, 'Expected the callback to be invoked when condition is false.');
+  }
+
+  public function test_it_does_not_execute_unless_callback_if_condition_is_true()
+  {
+    $invoker = $this->createPartialMock(Invoker::class, []);
+    $invoked = false;
+
+    $invoker->unless(true, function () use (&$invoked) {
+      $invoked = true;
+    });
+
+    $this->assertFalse($invoked, 'Expected the callback NOT to be invoked when condition is true.');
+  }
+
+  public function test_it_dispatches_job_with_invoker_through_asJob()
+  {
+    Queue::fake();
+
+    $invoker = Post::filter(new PostFilter());
+
+    $invoker->asJob(TestExecuteFilterJob::class, ['extra' => 'test']);
+
+    Queue::assertPushed(TestExecuteFilterJob::class, function ($job) use ($invoker) {
+      return $job->invoker === $invoker && $job->extra === 'test';
+    });
+  }
+
+  public function test_it_invoke_callback_on_error()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    /**
+     * @var Invoker
+     */
+    $result = Post::filter(new PostFilter);
+
+    $result->onError(function ($context, $th) {
+      throw new \InvalidArgumentException();
+    });
+
+    $result->whereHas('invalid', 'invalid');
+
+    $result->get();
+  }
+}

--- a/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
+++ b/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
@@ -4,8 +4,8 @@ namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
 use Illuminate\Database\Eloquent\Model;
 use Kettasoft\Filterable\Tests\TestCase;
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Traits\HasFilterable;
+use Illuminate\Contracts\Database\Query\Builder;
 use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
 use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
 

--- a/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
+++ b/tests/Unit/Filterable/FilterableModelAutoBindingTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Illuminate\Database\Eloquent\Model;
+use Kettasoft\Filterable\Tests\TestCase;
+use Illuminate\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Traits\HasFilterable;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+use Kettasoft\Filterable\Exceptions\FilterClassNotResolvedException;
+
+class FilterableModelAutoBindingTest extends TestCase
+{
+  public function test_it_applies_filter_automatically_from_model_property()
+  {
+    $model = new class extends Model {
+      use HasFilterable;
+      protected $filterable = PostFilter::class;
+    };
+
+    $this->assertInstanceOf(Builder::class, $model->filter());
+  }
+
+  public function test_it_throws_exception_if_no_filter_class_and_no_model_property()
+  {
+    $model = new class extends Model {
+      use HasFilterable;
+    };
+
+    $this->expectException(FilterClassNotResolvedException::class);
+
+    $model->filter();
+  }
+}

--- a/tests/Unit/Filterable/FilterableThroughTest.php
+++ b/tests/Unit/Filterable/FilterableThroughTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Tests\Http\Filters\PostFilter;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class FilterableThroughTest extends TestCase
+{
+  public function test_it_can_apply_filter_callbacks_with_through()
+  {
+    /**
+     * @var Filterable
+     */
+    $filter = Filterable::create()->setBuilder(Post::query());
+
+    $results = $filter->through([
+      fn($builder) => $builder->where('id', 1)
+    ]);
+
+    $this->assertNotEmpty($results->apply()->getBindings());
+  }
+
+  public function test_it_throws_exception_when_through_callback_is_invalid()
+  {
+    $this->expectException(\InvalidArgumentException::class);
+
+    /**
+     * @var Filterable
+     */
+    $filter = Filterable::create()->setBuilder(Post::query());
+
+    $filter->through([
+      'invalid args'
+    ]);
+  }
+}

--- a/tests/Unit/Filterable/FilterableWhenConditionTest.php
+++ b/tests/Unit/Filterable/FilterableWhenConditionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Filterable;
+
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class FilterableWhenConditionTest extends TestCase
+{
+  public function test_it_can_use_singel_when()
+  {
+    $filter = Filterable::create()->when(true, function (Filterable $filter) {
+      $filter->setAllowedFields(['test']);
+    });
+
+    $this->assertNotEmpty($filter->getAllowedFields());
+  }
+
+  public function test_it_cant_invoke_when_callback_with_false_condition()
+  {
+    $filter = Filterable::create()->when(false, function (Filterable $filter) {
+      $filter->setAllowedFields(['test']);
+    });
+
+    $this->assertEmpty($filter->getAllowedFields());
+  }
+
+  public function test_it_can_use_nested_when()
+  {
+    $filter = Filterable::create()->when(true, function (Filterable $filter) {
+      $filter->setAllowedFields(['test1']);
+
+      $filter->when(true, function (Filterable $filter) {
+        $filter->setAllowedFields(['test2', 'test3']);
+
+        $filter->when(true, fn($filter) => $filter->setAllowedFields(['test4']));
+
+        // Not working
+        $filter->when(false, function (Filterable $filter) {
+          $filter->setAllowedFields(['test2', 'test3']);
+        });
+      });
+    });
+
+    $this->assertCount(4, $filter->getAllowedFields());
+  }
+}

--- a/tests/Unit/Filterable/ModelToBuilderResolutionTest.php
+++ b/tests/Unit/Filterable/ModelToBuilderResolutionTest.php
@@ -2,10 +2,10 @@
 
 namespace Kettasoft\Filterable\Tests\Unit\Filterable;
 
-use Illuminate\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Filterable;
-use Kettasoft\Filterable\Tests\Models\Post;
 use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 class ModelToBuilderResolutionTest extends TestCase
 {


### PR DESCRIPTION
## Summary
This pull request merges the 2.0.0 branch into master, introducing a major new version of Filterable with extensive new features, enhancements, and breaking changes.

## Key Changes
- **Laravel 9, 10, 11, 12 support**
- **Filter Aliases:** Short names for filter classes
- **Auto Binding:** Models can define `$filterable` for automatic filter class resolution
- **Automatic `filter()` Macro Registration**
- **Profiler:** Query profiler for Filterable queries
- **New API for Through Callbacks**: `through()` method for query callbacks
- **Conditional Logic:** `when()` and `unless()` methods
- **Invoker Wrapper:** Extra control with before/after/onError hooks

### Breaking Changes
- Engine name corrected to `invokable`
- Trait inclusion moved to auto-registration
- Aliases and auto-discovery changes

## Other Updates
- Updated configuration file
- New and improved documentation
- Support for new dependencies
- Internal refactors and enhanced test coverage

For more details, see the full comparison between `master` and `v2.0.0` branches.
