### PR TITLE
Add helper methods to Payload class

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -110,6 +110,16 @@ export default defineUserConfig({
                 ],
             },
             {
+                text: "API",
+                collapsible: true,
+                children: [
+                    {
+                        text: "Payload",
+                        link: "api/payload",
+                    },
+                ],
+            },
+            {
                 text: "Profiler",
                 link: "profiler",
             },

--- a/docs/api/payload.md
+++ b/docs/api/payload.md
@@ -1,0 +1,286 @@
+# Payload
+
+The **Payload** class is a lightweight data wrapper used to represent a single filter input.  
+It normalizes values, provides utility methods, and makes it easier to work with common patterns such as wildcard search, JSON detection, boolean casting, and more.
+
+---
+
+## Overview
+
+When you define filters inside a `Filterable` class, the filter method receives a `Payload` object instead of a raw value.
+
+```php
+class PostFilter extends Filterable
+{
+    protected $filters = ['title'];
+
+    protected function title(Payload $payload)
+    {
+        return $this->builder->where('title', 'like', $payload->like());
+    }
+}
+```
+
+---
+
+## Properties
+
+| Property          | Type     | Description                            |
+| ----------------- | -------- | -------------------------------------- |
+| `$field`          | `string` | The field passed from the request.     |
+| `$operator`       | `string` | The operator passed from the request.  |
+| `$value`          | `mixed`  | The raw value passed from the request. |
+| `$beforeSanitize` | `mixed`  | The original value before sanitizing.  |
+
+---
+
+## Public Methods
+
+### `__toString(): string`
+
+Returns the value as string.
+
+```php
+(string) $payload; // equivalent to $payload->value
+```
+
+---
+
+### `length(): int`
+
+Get the length of the value.  
+Dealing with `array` or `string`
+
+```php
+if ($payload->length() > 10) {
+    // skip filter
+}
+```
+
+---
+
+### `isEmpty(): bool`
+
+Check if the value is empty (`null`, `""`, or whitespace).
+
+```php
+if ($payload->isEmpty()) {
+    // skip filter
+}
+```
+
+---
+
+### `isNotEmpty(): bool`
+
+Check if the value is not empty (`filterable`, `['one', 'tow']`, or any data).
+
+```php
+if ($payload->isNotEmpty()) {
+    // appliy filter
+}
+```
+
+---
+
+### `isNull(): bool`
+
+Check if the value is null.
+
+```php
+if ($payload->isNull()) {
+    // skip filter
+}
+```
+
+---
+
+### `isJson(): bool`
+
+Check if the payload is a valid JSON string.
+
+```php
+if ($payload->isJson()) {
+    $data = json_decode($payload->value, true);
+}
+```
+
+---
+
+### `asBoolean(): bool|null`
+
+Convert value to boolean.  
+Supports `"true"`, `"false"`, `"1"`, `"0"`, `"yes"`, `"no"`.
+
+```php
+$payload->asBoolean(); // true or false
+```
+
+---
+
+### `asLike(string $side = "both"): string`
+
+Wrap the value with `%` for SQL `LIKE` queries.
+
+-   `both` → `%value%`
+-   `left` → `%value`
+-   `right` → `value%`
+
+```php
+$this->builder->where('title', 'like', $payload->asLike());
+// WHERE title LIKE "%keyword%"
+```
+
+---
+
+### `asInt(): int`
+
+Cast value to integer.
+
+```php
+$payload->asInt(); // 42
+```
+
+---
+
+### `raw(): mixed`
+
+Get the original unmodified value.
+
+```php
+$payload->raw();  // equivalent to $payload->beforeSanitize
+```
+
+---
+
+### `isNumeric(): bool`
+
+Check if the value is numeric.
+
+```php
+if ($payload->isNumeric()) {
+    return $this->builder->where('id', $this->value);
+}
+```
+
+---
+
+### `isString(): bool`
+
+Check if the value is string.
+
+```php
+if ($payload->isString()) {
+    return $this->builder->where('name', $this->value);
+}
+```
+
+---
+
+### `isArray(): bool`
+
+Check if the value is array.
+
+```php
+if ($payload->isArray()) {
+    return $this->builder->where('name', 'in', $this->value);
+}
+```
+
+---
+
+### `isTrue(): bool`
+
+Check if the value is `true`.  
+Supports `"true"`, `"1"`, `"yes"`.
+
+```php
+$payload->isTrue(); // true
+```
+
+---
+
+### `isFalse(): bool`
+
+Check if the value is `false`.  
+Supports `"false"`, `"0"`, `"no"`, `""`.
+
+```php
+$payload->isFalse();
+```
+
+---
+
+### `asArray(): array`
+
+If the value is a valid JSON string representing an array/object, it will be decoded into an array.
+If the value is already an array, it will be returned directly. Otherwise returns null.
+
+```php
+$payload->asArray();
+```
+
+---
+
+### `toArray(): array`
+
+Get the instance as an array
+
+```php
+$payload->toArray();
+
+/*
+  [
+    "field" => "status",
+    "operator" => "=",
+    "value" => "filterable"
+  ]
+*/
+```
+
+---
+
+### `toJson(): string`
+
+Get the instance as an json string
+
+```php
+$payload->toJson();
+
+/*
+  [
+    "field" => "status",
+    "operator" => "=",
+    "value" => "filterable"
+  ]
+*/
+```
+
+## Example Usage
+
+```php
+protected function status(Payload $payload)
+{
+    return $this->builder->where('is_active', $payload->asBoolean());
+}
+
+protected function category(Payload $payload)
+{
+    return $this->builder->where('category_id', $payload->asInt());
+}
+
+protected function meta(Payload $payload)
+{
+    if ($payload->isJson()) {
+        return $this->builder->whereJsonContains('meta', $payload->raw());
+    }
+}
+```
+
+---
+
+## Summary
+
+-   `Payload` standardizes how filter values are processed.
+-   It provides helper methods (`asLike`, `asBoolean`, `isJson`, etc.).
+-   This reduces repetitive code inside filter classes.

--- a/src/Support/Payload.php
+++ b/src/Support/Payload.php
@@ -64,6 +64,215 @@ readonly class Payload implements \Stringable, Arrayable, Jsonable
   }
 
   /**
+   * Get the original unmodified value.
+   * 
+   * @return mixed
+   */
+  public function raw(): mixed
+  {
+    return $this->beforeSanitize;
+  }
+
+  /**
+   * Get the length of the payload value.
+   * 
+   * @return int
+   */
+  public function length(): int
+  {
+    return is_string($this->value) ? mb_strlen($this->value) : count((array) $this->value);
+  }
+
+  /**
+   * Check if the payload is empty.
+   *
+   * @return bool
+   */
+  public function isEmpty(): bool
+  {
+    return empty($this->value);
+  }
+
+  /**
+   * Check if the payload is not empty.
+   *
+   * @return bool
+   */
+  public function isNotEmpty(): bool
+  {
+    return !$this->isEmpty();
+  }
+
+  /**
+   * Check if the payload value is null.
+   *
+   * @return bool
+   */
+  public function isNull(): bool
+  {
+    return is_null($this->value);
+  }
+
+  /**
+   * Check if the payload value is a boolean.
+   *
+   * @return bool
+   */
+  public function isBoolean(): bool
+  {
+    if (is_bool($this->value)) {
+      return true;
+    }
+
+    return filter_var($this->value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) !== null;
+  }
+
+  /**
+   * Check if the payload value is a valid JSON string.
+   *
+   * @param bool $strict When true, only JSON objects/arrays are considered valid.
+   *                     When false, any valid JSON (string, number, boolean, null, object, array) is accepted.
+   * @return bool
+   */
+  public function isJson(bool $strict = true): bool
+  {
+    if (!is_string($this->value)) {
+      return false;
+    }
+
+    $decoded = json_decode($this->value, true);
+
+    if (json_last_error() !== JSON_ERROR_NONE) {
+      return false;
+    }
+
+    if ($strict) {
+      return is_array($decoded);
+    }
+
+    return true;
+  }
+
+  /**
+   * Check if the payload value is numeric.
+   * 
+   * @return bool
+   */
+  public function isNumeric(): bool
+  {
+    return is_numeric($this->value);
+  }
+
+  /**
+   * Check if the payload value is a string.
+   *
+   * @return bool
+   */
+  public function isString(): bool
+  {
+    return is_string($this->value);
+  }
+
+  /**
+   * Check if the payload value is an array.
+   *
+   * @return bool
+   */
+  public function isArray(): bool
+  {
+    return is_array($this->value);
+  }
+
+  /**
+   * Check if the payload value is true.
+   *
+   * @return bool
+   */
+  public function isTrue(): bool
+  {
+    return $this->isBoolean() && filter_var($this->value, FILTER_VALIDATE_BOOLEAN) === true;
+  }
+
+  /**
+   * Check if the payload value is false.
+   *
+   * @return bool
+   */
+  public function isFalse(): bool
+  {
+    return $this->isBoolean() && filter_var($this->value, FILTER_VALIDATE_BOOLEAN) === false;
+  }
+
+  /**
+   * Get the payload value as a boolean.
+   *
+   * Returns `true` or `false` if the value can be interpreted as a boolean
+   * (e.g. actual bool, "true", "false", 1, 0, "1", "0"), otherwise returns null.
+   *
+   * @return bool|null
+   */
+  public function asBoolean(): ?bool
+  {
+    return $this->isBoolean() ? filter_var($this->value, FILTER_VALIDATE_BOOLEAN) : null;
+  }
+
+  /**
+   * Get the payload value as an array.
+   *
+   * If the value is a valid JSON string representing an array/object,
+   * it will be decoded into an array. If the value is already an array,
+   * it will be returned directly. Otherwise returns null.
+   *
+   * @return array<TKey, TValue>|null
+   */
+  public function asArray(): ?array
+  {
+    return $this->isJson() ? json_decode($this->value, true) : (is_array($this->value) ? $this->value : null);
+  }
+
+  /**
+   * Get the payload value as an integer.
+   *
+   * If the value is numeric, it will be cast to int. Otherwise returns null.
+   *
+   * @return int|null
+   */
+  public function asInt(): ?int
+  {
+    return $this->isNumeric() ? (int) $this->value : null;
+  }
+
+  /**
+   * Wrap the value with a given prefix and suffix.
+   *
+   * @param string $prefix
+   * @param string $suffix
+   * @return string
+   */
+  protected function wrap(string $prefix, string $suffix): string
+  {
+    return sprintf('%s%s%s', $prefix, $this->value, $suffix);
+  }
+
+  /**
+   * Get the value wrapped for a LIKE query.
+   *
+   * Example: "%value%", "value%", "%value", etc.
+   *
+   * @param string $side
+   * @return string
+   */
+  public function asLike(string $side = 'both'): string
+  {
+    return match ($side) {
+      'both' => $this->wrap('%', '%'),
+      'start' => $this->wrap('%', ''),
+      'end' => $this->wrap('', '%'),
+      default => throw new \InvalidArgumentException(sprintf("The side value is not valid. valid sides: %s, %s, %s", 'both', 'start', 'end'))
+    };
+  }
+
+  /**
    * Get the instance as an array.
    *
    * @return array<TKey, TValue>
@@ -92,7 +301,7 @@ readonly class Payload implements \Stringable, Arrayable, Jsonable
   /**
    * Return request value on read class as a string.
    */
-  public function __tostring()
+  public function __toString()
   {
     return $this->value;
   }

--- a/tests/Unit/Support/PayloadTest.php
+++ b/tests/Unit/Support/PayloadTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Support;
+
+use Kettasoft\Filterable\Tests\TestCase;
+use Kettasoft\Filterable\Support\Payload;
+
+class PayloadTest extends TestCase
+{
+  protected Payload $payload;
+
+  public function setUp(): void
+  {
+    parent::setUp();
+
+    $this->payload = new Payload(
+      field: 'name',
+      operator: '=',
+      value: 'Filterable',
+      beforeSanitize: '   Filterable   '
+    );
+  }
+
+  public function test_it_can_be_instantiated()
+  {
+    $this->assertInstanceOf(Payload::class, $this->payload);
+    $this->assertEquals('name', $this->payload->field);
+    $this->assertEquals('=', $this->payload->operator);
+    $this->assertEquals('Filterable', $this->payload->value);
+    $this->assertEquals('   Filterable   ', $this->payload->beforeSanitize);
+  }
+
+  public function test_static_create_method()
+  {
+    $payload = Payload::create('age', '>', 25, '25');
+    $this->assertInstanceOf(Payload::class, $payload);
+    $this->assertEquals(25, $payload->value);
+  }
+
+  public function test_length_method()
+  {
+    $this->assertEquals(10, $this->payload->length());
+
+    $arrayPayload = new Payload('tags', 'IN', ['php', 'laravel'], ['php', 'laravel']);
+    $this->assertEquals(2, $arrayPayload->length());
+  }
+
+  public function test_empty_and_not_empty()
+  {
+    $emptyPayload = new Payload('name', '=', '', '');
+    $this->assertTrue($emptyPayload->isEmpty());
+    $this->assertFalse($emptyPayload->isNotEmpty());
+
+    $this->assertTrue($this->payload->isNotEmpty());
+  }
+
+  public function test_null_check()
+  {
+    $nullPayload = new Payload('name', '=', null, null);
+    $this->assertTrue($nullPayload->isNull());
+  }
+
+  public function test_boolean_checks()
+  {
+    $truePayload = new Payload('active', '=', true, true);
+    $falsePayload = new Payload('active', '=', 'false', 'false');
+
+    $this->assertTrue($truePayload->isBoolean());
+    $this->assertTrue($falsePayload->isBoolean());
+
+    $this->assertTrue($truePayload->isTrue());
+    $this->assertTrue($falsePayload->isFalse());
+
+    $this->assertTrue($truePayload->asBoolean());
+    $this->assertFalse($falsePayload->asBoolean());
+  }
+
+  public function test_json_checks()
+  {
+    $jsonPayload = new Payload('data', '=', '{"name":"John"}', '{"name":"John"}');
+    $this->assertTrue($jsonPayload->isJson());
+    $this->assertIsArray($jsonPayload->asArray());
+    $this->assertEquals(['name' => 'John'], $jsonPayload->asArray());
+
+    $strictInvalid = new Payload('data', '=', '"string"', '"string"');
+    $this->assertFalse($strictInvalid->isJson(true));
+    $this->assertTrue($strictInvalid->isJson(false));
+  }
+
+  public function test_numeric_checks()
+  {
+    $numericPayload = new Payload('age', '=', '42', '42');
+    $this->assertTrue($numericPayload->isNumeric());
+    $this->assertEquals(42, $numericPayload->asInt());
+  }
+
+  public function test_string_and_array_checks()
+  {
+    $this->assertTrue($this->payload->isString());
+
+    $arrayPayload = new Payload('ids', 'IN', [1, 2, 3], [1, 2, 3]);
+    $this->assertTrue($arrayPayload->isArray());
+  }
+
+  public function test_wrap_and_like_helpers()
+  {
+    $this->assertEquals('%Filterable%', $this->payload->asLike());
+    $this->assertEquals('%Filterable', $this->payload->asLike('start'));
+    $this->assertEquals('Filterable%', $this->payload->asLike('end'));
+  }
+
+  public function test_to_array_and_json()
+  {
+    $array = $this->payload->toArray();
+    $this->assertArrayHasKey('field', $array);
+    $this->assertArrayHasKey('operator', $array);
+
+    $json = $this->payload->toJson();
+    $this->assertJson($json);
+  }
+
+  public function test_to_string_returns_value()
+  {
+    $this->assertEquals('Filterable', (string) $this->payload);
+  }
+}


### PR DESCRIPTION
### Summary
This PR introduces new helper methods to the `Payload` class that make it easier
to work with common filter patterns such as LIKE queries, JSON detection, boolean casting, and type conversions.

### Details
- Added helper methods:
  - `asLike()` → wraps value with % for SQL LIKE queries.
  - `asBoolean()` → safely cast value to boolean (supports "true"/"false"/"1"/"0"/etc.).
  - `asInt()` → type casting for numeric value.
  - `isJson()` → check if value is a valid JSON string.
  - `raw()` → get the unmodified original value.
  - And more...
- Added docs (`payload.md`) to VuePress with examples and usage guidelines.

### Why
These enhancements simplify filter implementation by:
- Reducing boilerplate in filter methods.
- Making payload usage more expressive and readable.
- Providing safe, reusable conversions out of the box.