### PR TITLE
feat: support custom make-filter path and namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Add the following line to the providers array in config/app.php or bootstrap/pro
 php artisan filterable:make-filter PostFilter --filters=title,status
 ```
 
+To generate the class in a custom namespace or directory:
+
+```bash
+php artisan filterable:make-filter PostFilter \
+  --namespace="Modules\\Blog\\App\\Filters" \
+  --path="Modules/Blog/app/Filters"
+```
+
 **2. Define your filters**
 
 ```php

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -8,7 +8,9 @@ return [
     | Eloquent Filter Settings
     |--------------------------------------------------------------------------
     |
-    | This is the namespace all you Eloquent Model Filters will reside
+    | This is the default namespace used when generating new filter classes.
+    | You can override it per command with:
+    | php artisan filterable:make-filter UserFilter --namespace="Modules\Blog\App\Filters"
     |
     */
     'namespace' => 'App\\Http\\Filters',
@@ -18,7 +20,9 @@ return [
     | Path of saving new filters
     |--------------------------------------------------------------------------
     |
-    | This is the namespace all you Eloquent Model Filters will reside
+    | This is the default directory used when creating new filter files.
+    | You can override it per command with:
+    | php artisan filterable:make-filter UserFilter --path="Modules/Blog/app/Filters"
     |
     */
     'save_filters_at' => app_path('Http/Filters'),

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -57,6 +57,15 @@ When executed, this command will:
     php artisan filterable:make-filter PostFilter --filters=author,title
     ```
 
+   If you need to generate a filter in a custom location, you can override the
+   default target at generation time:
+
+    ```bash
+    php artisan filterable:make-filter PostFilter \
+      --namespace="Modules\\Blog\\App\\Filters" \
+      --path="Modules/Blog/app/Filters"
+    ```
+
 ---
 
 ### **Example Output**
@@ -67,7 +76,7 @@ When executed, this command will:
 📁 Created directory: app/Http/Filters
 
 🎉 Setup complete! You can now create your first filter with:
-php artisan filterable:make PostFilter --filters=test
+php artisan filterable:make-filter PostFilter --filters=test
 ```
 
 ---
@@ -76,6 +85,7 @@ php artisan filterable:make PostFilter --filters=test
 
 -   Use the `--force` flag if you want to **re-publish** the configuration file and overwrite existing settings.
 -   The command automatically detects whether the `app/Http/Filters` directory already exists.
+-   `filterable:make-filter` uses the defaults from `config/filterable.php`, but you can override them per run with `--namespace` and `--path`.
 
 ---
 

--- a/src/Commands/MakeFilterCommand.php
+++ b/src/Commands/MakeFilterCommand.php
@@ -5,14 +5,15 @@ namespace Kettasoft\Filterable\Commands;
 use Illuminate\Support\Str;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Config;
 use Kettasoft\Filterable\Support\Stub;
 
 class MakeFilterCommand extends Command
 {
-  protected $signature = 'filterable:make-filter 
-                            {name : The filter class name} 
+  protected $signature = 'filterable:make-filter
+                            {name : The filter class name}
                             {--filters= : Comma-separated filter methods (e.g. status,title)}
+                            {--namespace= : Override the generated class namespace}
+                            {--path= : Override the directory where the filter file will be created}
                             {--force : Overwrite existing filter if it exists}';
 
   protected $description = 'Create a new Eloquent filter class';
@@ -20,19 +21,22 @@ class MakeFilterCommand extends Command
   public function handle()
   {
     $name = trim($this->argument('name'));
+    $class = $this->resolveClassName($name);
     $keys = $this->option('filters');
+    $savePath = $this->getFilterSavingPath();
+    $namespace = $this->getFilterNamespace();
+    $filePath = $savePath . "/{$class}.php";
 
     Stub::setBasePath(config('filterable.generator.stubs'));
 
     // Ensure directory exists
-    $savePath = $this->getFilterSavingPath();
     if (!File::exists($savePath)) {
       File::makeDirectory($savePath, 0755, true);
     }
 
     // Prevent overwriting existing files
-    if (File::exists($savePath . "/{$name}.php") && !$this->option('force')) {
-      $this->error("❌ Filter class '{$name}.php' already exists at {$savePath}.");
+    if (File::exists($filePath) && !$this->option('force')) {
+      $this->error("❌ Filter class '{$class}.php' already exists at {$savePath}.");
       $this->warn('Use the --force option to overwrite it.');
       return Command::FAILURE;
     }
@@ -40,13 +44,13 @@ class MakeFilterCommand extends Command
     // If no filters provided → create simple class
     if (!$keys) {
       Stub::create('filter.stub', [
-        'CLASS' => $name,
+        'CLASS' => $class,
         'FILTER_KEYS' => '',
         'METHODS' => '',
-        'NAMESPACE' => Config::get('filterable.filter_namespace', 'App\\Http\\Filters')
-      ])->saveTo($savePath, "{$name}.php");
+        'NAMESPACE' => $namespace,
+      ])->saveTo($savePath, "{$class}.php");
 
-      $this->info("✅ Filter class '{$name}.php' created successfully.");
+      $this->info("✅ Filter class '{$class}.php' created successfully.");
       return Command::SUCCESS;
     }
 
@@ -69,18 +73,71 @@ class MakeFilterCommand extends Command
 
     // Create final filter class
     Stub::create('filter.stub', [
-      'CLASS' => $name,
+      'CLASS' => $class,
       'METHODS' => implode("\n\n", $methods),
       'FILTER_KEYS' => "'" . implode("','", $keys) . "'",
-      'NAMESPACE' => Config::get('filterable.filter_namespace', 'App\\Http\\Filters')
-    ])->saveTo($savePath, "{$name}.php");
+      'NAMESPACE' => $namespace,
+    ])->saveTo($savePath, "{$class}.php");
 
-    $this->info("✅ Filter '{$name}.php' created successfully with methods: " . implode(', ', $keys));
+    $this->info("✅ Filter '{$class}.php' created successfully with methods: " . implode(', ', $keys));
     return Command::SUCCESS;
   }
 
+  /**
+   * Get the filter saving path.
+   *
+   * @return string
+   */
   protected function getFilterSavingPath(): string
   {
-    return config('filterable.save_filters_at', app_path('Http/Filters'));
+    $path = trim((string) $this->option('path'));
+
+    if ($path === '') {
+      return rtrim((string) config('filterable.save_filters_at', app_path('Http/Filters')), '/\\');
+    }
+
+    if ($this->isAbsolutePath($path)) {
+      return rtrim($path, '/\\');
+    }
+
+    return rtrim(base_path($path), '/\\');
+  }
+
+  /**
+   * Get the filter namespace.
+   *
+   * @return string
+   */
+  protected function getFilterNamespace(): string
+  {
+    $namespace = trim((string) $this->option('namespace'));
+
+    if ($namespace === '') {
+      $namespace = (string) config('filterable.namespace', config('filterable.filter_namespace', 'App\\Http\\Filters'));
+    }
+
+    return trim(str_replace('/', '\\', $namespace), '\\');
+  }
+
+  /**
+   * Resolve the class name from the given name.
+   *
+   * @param string $name
+   * @return string
+   */
+  protected function resolveClassName(string $name): string
+  {
+    return Str::of($name)->replace('/', '\\')->afterLast('\\')->toString();
+  }
+
+  /**
+   * Check if the given path is an absolute path.
+   *
+   * @param string $path
+   * @return bool
+   */
+  protected function isAbsolutePath(string $path): bool
+  {
+    return Str::startsWith($path, ['/']) || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1;
   }
 }

--- a/tests/Feature/Commands/MakeFilterCommandTest.php
+++ b/tests/Feature/Commands/MakeFilterCommandTest.php
@@ -5,7 +5,6 @@ namespace Kettasoft\Filterable\Tests\Feature\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\File;
-use Kettasoft\Filterable\Support\Stub;
 use Kettasoft\Filterable\Tests\TestCase;
 
 class MakeFilterCommandTest extends TestCase
@@ -20,6 +19,8 @@ class MakeFilterCommandTest extends TestCase
   {
     parent::setUp();
 
+    config()->set('filterable.namespace', 'App\\Http\\Filters');
+    config()->set('filterable.save_filters_at', base_path('tests/tmp/Filters'));
     config()->set('filterable.generator.stubs', __DIR__ . '/../../../stubs/');
   }
 
@@ -30,7 +31,7 @@ class MakeFilterCommandTest extends TestCase
    */
   protected function tearDown(): void
   {
-    File::deleteDirectory(config('filterable.save_filters_at'));
+    File::deleteDirectory(base_path('tests/tmp'));
 
     parent::tearDown();
   }
@@ -42,13 +43,15 @@ class MakeFilterCommandTest extends TestCase
   public function it_creates_basic_filter_file()
   {
     $filename = 'UserFilter';
+    $filePath = base_path("tests/tmp/Filters/{$filename}.php");
 
     $result = Artisan::call("filterable:make-filter", [
       "name" => $filename
     ]);
 
     $this->assertEquals(Command::SUCCESS, $result);
-    $this->assertTrue(File::exists(app_path('Http/Filters') . "/$filename.php"));
+    $this->assertTrue(File::exists($filePath));
+    $this->assertStringContainsString('namespace App\\Http\\Filters;', File::get($filePath));
   }
 
   /**
@@ -58,6 +61,7 @@ class MakeFilterCommandTest extends TestCase
   public function it_creates_filter_with_methods_file()
   {
     $filename = 'UserFilter';
+    $filePath = base_path("tests/tmp/Filters/{$filename}.php");
 
     $result = Artisan::call("filterable:make-filter", [
       "name" => $filename,
@@ -65,6 +69,29 @@ class MakeFilterCommandTest extends TestCase
     ]);
 
     $this->assertEquals(Command::SUCCESS, $result);
-    $this->assertTrue(File::exists(app_path('Http/Filters') . "/$filename.php"));
+    $this->assertTrue(File::exists($filePath));
+    $this->assertStringContainsString("public function methods(Payload \$payload)", File::get($filePath));
+  }
+
+  /**
+   * It creates filter file using custom path and namespace options.
+   * @test
+   */
+  public function it_creates_filter_file_using_custom_path_and_namespace_options()
+  {
+    $filename = 'BlogPostFilter';
+    $relativePath = 'tests/tmp/Modules/Blog/app/Filters';
+    $namespace = 'Modules\\Blog\\App\\Filters';
+    $filePath = base_path("{$relativePath}/{$filename}.php");
+
+    $result = Artisan::call("filterable:make-filter", [
+      "name" => $filename,
+      '--path' => $relativePath,
+      '--namespace' => $namespace,
+    ]);
+
+    $this->assertEquals(Command::SUCCESS, $result);
+    $this->assertTrue(File::exists($filePath));
+    $this->assertStringContainsString("namespace {$namespace};", File::get($filePath));
   }
 }


### PR DESCRIPTION
## Summary
- add `--path` and `--namespace` options to `filterable:make-filter`
- resolve custom generation targets while preserving configured defaults as fallbacks
- document the new generator overrides and extend command tests to cover them

## Test plan
- [x] Run `php vendor/bin/phpunit tests/Feature/Commands/MakeFilterCommandTest.php`