### PR TITLE
feat: refactor Skip Strategy to track Payload objects

### DIFF
--- a/src/Engines/Contracts/Skippable.php
+++ b/src/Engines/Contracts/Skippable.php
@@ -3,15 +3,17 @@
 namespace Kettasoft\Filterable\Engines\Contracts;
 
 use Kettasoft\Filterable\Engines\Exceptions\SkipExecution;
+use Kettasoft\Filterable\Support\Payload;
 
 interface Skippable
 {
     /**
-     * Skip the current execution with a message and optional clause.
-     * @param string $message
-     * @param mixed $clause
+     * Skip the current execution with a message and optional payload.
+     * 
+     * @param string $message The reason for skipping
+     * @param Payload|null $payload The payload being skipped
      * @throws SkipExecution
      * @return never
      */
-    public function skip(string $message, mixed $clause = null): never;
+    public function skip(string $message, mixed $payload = null): never;
 }

--- a/src/Engines/Contracts/Skippable.php
+++ b/src/Engines/Contracts/Skippable.php
@@ -10,10 +10,10 @@ interface Skippable
     /**
      * Skip the current execution with a message and optional payload.
      * 
-     * @param string $message The reason for skipping
-     * @param Payload|null $payload The payload being skipped
+     * @param Payload $payload The payload being skipped
+     * @param string|null $message The reason for skipping
      * @throws SkipExecution
      * @return never
      */
-    public function skip(string $message, mixed $payload = null): never;
+    public function skip(Payload $payload, ?string $message = null): never;
 }

--- a/src/Engines/Exceptions/InvalidOperatorException.php
+++ b/src/Engines/Exceptions/InvalidOperatorException.php
@@ -2,14 +2,17 @@
 
 namespace Kettasoft\Filterable\Engines\Exceptions;
 
+use Kettasoft\Filterable\Support\Payload;
+
 class InvalidOperatorException extends SkipExecution
 {
   /**
    * InvalidOperatorException constructor.
    * @param string $operator
+   * @param Payload|null $payload
    */
-  public function __construct(string $operator)
+  public function __construct(string $operator, ?Payload $payload = null)
   {
-    parent::__construct(sprintf("Operator [$operator] is invalid"));
+    parent::__construct(sprintf("Operator [$operator] is invalid"), $payload);
   }
 }

--- a/src/Engines/Exceptions/NotAllowedEmptyValueException.php
+++ b/src/Engines/Exceptions/NotAllowedEmptyValueException.php
@@ -2,14 +2,17 @@
 
 namespace Kettasoft\Filterable\Engines\Exceptions;
 
+use Kettasoft\Filterable\Support\Payload;
+
 class NotAllowedEmptyValueException extends SkipExecution
 {
     /**
      * NotAllowedEmptyValueException constructor.
-     * @param mixed $message
+     * @param string $message
+     * @param Payload|null $payload
      */
-    public function __construct($message = "")
+    public function __construct(string $message = "", ?Payload $payload = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, $payload);
     }
 }

--- a/src/Engines/Exceptions/NotAllowedFieldException.php
+++ b/src/Engines/Exceptions/NotAllowedFieldException.php
@@ -2,14 +2,17 @@
 
 namespace Kettasoft\Filterable\Engines\Exceptions;
 
+use Kettasoft\Filterable\Support\Payload;
+
 class NotAllowedFieldException extends SkipExecution
 {
   /**
    * NotAllowedFieldException constructor.
    * @param string $field
+   * @param Payload|null $payload
    */
-  public function __construct(string $field)
+  public function __construct(string $field, ?Payload $payload = null)
   {
-    parent::__construct(sprintf("Field [$field] is not allowed."));
+    parent::__construct(sprintf("Field [$field] is not allowed."), $payload);
   }
 }

--- a/src/Engines/Exceptions/SkipExecution.php
+++ b/src/Engines/Exceptions/SkipExecution.php
@@ -3,27 +3,27 @@
 namespace Kettasoft\Filterable\Engines\Exceptions;
 
 use Exception;
-use Kettasoft\Filterable\Engines\Foundation\Clause;
+use Kettasoft\Filterable\Support\Payload;
 
 class SkipExecution extends Exception
 {
     /**
      * SkipExecution constructor.
      * @param string $message
-     * @param mixed $clause
+     * @param Payload|null $payload
      */
-    public function __construct(string $message, protected mixed $clause = null)
+    public function __construct(string $message, protected ?Payload $payload = null)
     {
         parent::__construct($message);
     }
 
     /**
-     * Get the associated Clause.
-     * @return ?Clause
+     * Get the associated Payload that was skipped.
+     * @return Payload|null
      */
-    public function getClause(): ?Clause
+    public function getPayload(): ?Payload
     {
-        return $this->clause;
+        return $this->payload;
     }
 
     /**

--- a/src/Engines/Foundation/Attributes/Annotations/Authorize.php
+++ b/src/Engines/Foundation/Attributes/Annotations/Authorize.php
@@ -38,7 +38,10 @@ class Authorize implements \Kettasoft\Filterable\Engines\Foundation\Attributes\C
     $authorize = new $this->authorize;
 
     if (! $authorize->authorize()) {
-      throw new \Kettasoft\Filterable\Engines\Exceptions\SkipExecution("Authorization failed for class '{$this->authorize}'.");
+      throw new \Kettasoft\Filterable\Engines\Exceptions\SkipExecution(
+        "Authorization failed for class '{$this->authorize}'.",
+        $context->payload
+      );
     }
   }
 }

--- a/src/Engines/Foundation/Attributes/Annotations/Between.php
+++ b/src/Engines/Foundation/Attributes/Annotations/Between.php
@@ -42,7 +42,8 @@ class Between implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Con
 
     if (! is_numeric($payload->value)) {
       throw new SkipExecution(
-        "The value '{$payload->value}' is not numeric. Expected a value between {$this->min} and {$this->max}."
+        "The value '{$payload->value}' is not numeric. Expected a value between {$this->min} and {$this->max}.",
+        $payload
       );
     }
 
@@ -50,7 +51,8 @@ class Between implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Con
 
     if ($value < $this->min || $value > $this->max) {
       throw new SkipExecution(
-        "The value '{$value}' is not between {$this->min} and {$this->max}."
+        "The value '{$value}' is not between {$this->min} and {$this->max}.",
+        $payload
       );
     }
   }

--- a/src/Engines/Foundation/Attributes/Annotations/DependsOn.php
+++ b/src/Engines/Foundation/Attributes/Annotations/DependsOn.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Kettasoft\Filterable\Engines\Foundation\Attributes\Annotations;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD)]
+class DependsOn implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Contracts\MethodAttribute
+{
+  /**
+   * Constructor for DependsOn attribute.
+   * @param string $dependsOn The name of the filter method that this filter depends on.
+   */
+  public function __construct(public string|array $dependsOn) {}
+
+  /**
+   * Get the stage at which this attribute should be applied.
+   *
+   * @return int
+   */
+  public static function stage(): int
+  {
+    return \Kettasoft\Filterable\Engines\Foundation\Attributes\Enums\Stage::CONTROL->value;
+  }
+
+  /**
+   * Handle the attribute logic.
+   *
+   * @param \Kettasoft\Filterable\Engines\Foundation\Attributes\AttributeContext $context
+   * @return void
+   */
+  public function handle(\Kettasoft\Filterable\Engines\Foundation\Attributes\AttributeContext $context): void
+  {
+    $payload = $context->payload;
+  }
+}

--- a/src/Engines/Foundation/Attributes/Annotations/In.php
+++ b/src/Engines/Foundation/Attributes/Annotations/In.php
@@ -46,7 +46,8 @@ class In implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Contract
 
     if ($payload->notIn($this->values)) {
       throw new \Kettasoft\Filterable\Engines\Exceptions\SkipExecution(
-        "The value '{$payload->value}' is not in the allowed set: " . implode(', ', $this->values)
+        "The value '{$payload->value}' is not in the allowed set: " . implode(', ', $this->values),
+        $payload
       );
     }
   }

--- a/src/Engines/Foundation/Attributes/Annotations/MapValue.php
+++ b/src/Engines/Foundation/Attributes/Annotations/MapValue.php
@@ -63,7 +63,8 @@ class MapValue implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Co
 
     if ($this->strict) {
       throw new \Kettasoft\Filterable\Engines\Exceptions\SkipExecution(
-        "The value '{$key}' is not in the value map: " . implode(', ', array_keys($this->map))
+        "The value '{$key}' is not in the value map: " . implode(', ', array_keys($this->map)),
+        $payload
       );
     }
   }

--- a/src/Engines/Foundation/Attributes/Annotations/Regex.php
+++ b/src/Engines/Foundation/Attributes/Annotations/Regex.php
@@ -42,13 +42,15 @@ class Regex implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Contr
 
     if (! is_string($payload->value)) {
       throw new SkipExecution(
-        $this->message ?: "The value is not a string and cannot be matched against pattern '{$this->pattern}'."
+        $this->message ?: "The value is not a string and cannot be matched against pattern '{$this->pattern}'.",
+        $payload
       );
     }
 
     if (! preg_match($this->pattern, $payload->value)) {
       throw new SkipExecution(
-        $this->message ?: "The value '{$payload->value}' does not match the pattern '{$this->pattern}'."
+        $this->message ?: "The value '{$payload->value}' does not match the pattern '{$this->pattern}'.",
+        $payload
       );
     }
   }

--- a/src/Engines/Foundation/Attributes/Annotations/SkipIf.php
+++ b/src/Engines/Foundation/Attributes/Annotations/SkipIf.php
@@ -63,7 +63,8 @@ class SkipIf implements \Kettasoft\Filterable\Engines\Foundation\Attributes\Cont
 
     if ($result) {
       throw new SkipExecution(
-        $this->message ?: "Filter skipped because payload {$this->check} check was true."
+        $this->message ?: "Filter skipped because payload {$this->check} check was true.",
+        $payload
       );
     }
   }

--- a/src/Engines/Foundation/ClauseFactory.php
+++ b/src/Engines/Foundation/ClauseFactory.php
@@ -61,7 +61,7 @@ class ClauseFactory
     // allow wildcard * as "all fields allowed"
     $isWildcardAllowed = ($this->engine->getAllowedFields()[0] ?? false) === '*';
     if (!(in_array($field, $this->engine->getAllowedFields(), true) || $this->isRelational($field) || $isWildcardAllowed)) {
-      throw new NotAllowedFieldException($field);
+      throw new NotAllowedFieldException($field, $payload);
     }
 
     return;
@@ -97,7 +97,7 @@ class ClauseFactory
   protected function validateValue(Payload $payload): void
   {
     if ($this->engine->isIgnoredEmptyValues() && $payload->isEmpty()) {
-      throw new NotAllowedEmptyValueException("Empty values are not allowed.");
+      throw new NotAllowedEmptyValueException("Empty values are not allowed.", $payload);
     }
 
     return;

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -51,11 +51,16 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
   }
 
   /**
-   * @inheritDoc
+   * Skip the current filter execution with a message and payload.
+   * 
+   * @param string $message The reason for skipping
+   * @param \Kettasoft\Filterable\Support\Payload|null $payload The payload being skipped
+   * @return never
+   * @throws SkipExecution
    */
-  public function skip(string $message, mixed $clause = null): never
+  public function skip(string $message, mixed $payload = null): never
   {
-    throw new SkipExecution($message, $clause);
+    throw new SkipExecution($message, $payload);
   }
 
   /**

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -13,6 +13,7 @@ use Kettasoft\Filterable\Engines\Contracts\HasFieldMap;
 use Kettasoft\Filterable\Engines\Exceptions\SkipExecution;
 use Kettasoft\Filterable\Engines\Contracts\HasAllowedFieldChecker;
 use Kettasoft\Filterable\Engines\Contracts\HasInteractsWithOperators;
+use Kettasoft\Filterable\Support\Payload;
 
 abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Strictable, Executable, HasAllowedFieldChecker, Skippable
 {
@@ -53,12 +54,12 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
   /**
    * Skip the current filter execution with a message and payload.
    * 
+   * @param \Kettasoft\Filterable\Support\Payload $payload The payload being skipped
    * @param string $message The reason for skipping
-   * @param \Kettasoft\Filterable\Support\Payload|null $payload The payload being skipped
    * @return never
    * @throws SkipExecution
    */
-  public function skip(string $message, mixed $payload = null): never
+  public function skip(Payload $payload, ?string $message = null): never
   {
     throw new SkipExecution($message, $payload);
   }

--- a/src/Engines/Foundation/Handlers/AllowedFieldValidator.php
+++ b/src/Engines/Foundation/Handlers/AllowedFieldValidator.php
@@ -14,7 +14,7 @@ class AllowedFieldValidator
    * Check if field is allowed to apply filtering.
    * @param \Kettasoft\Filterable\Engines\Contracts\HasAllowedFieldChecker $engine
    * @param mixed $field
-   * @throws \Kettasoft\Filterable\Exceptions\NotAllowedFieldException
+   * @throws \Kettasoft\Filterable\Engines\Exceptions\NotAllowedFieldException
    * @return bool
    */
   final public static function validate(Engine $engine, $field)
@@ -29,11 +29,11 @@ class AllowedFieldValidator
   /**
    * Throw field is not allowed.
    * @param mixed $field
-   * @throws \Kettasoft\Filterable\Exceptions\NotAllowedFieldException
+   * @throws \Kettasoft\Filterable\Engines\Exceptions\NotAllowedFieldException
    * @return never
    */
   protected static function throw($field)
   {
-    throw new NotAllowedFieldException($field);
+    throw new NotAllowedFieldException($field, null);
   }
 }

--- a/src/Exceptions/Handlers/DefaultHandler.php
+++ b/src/Exceptions/Handlers/DefaultHandler.php
@@ -20,6 +20,11 @@ class DefaultHandler extends FilterableExceptionHandler
         if ($this->hasSkipping($exception)) {
             /** @var SkipExecution $exception */
 
+            // Register the skipped payload in the context
+            if ($payload = $exception->getPayload()) {
+                $engine->getContext()->skip($payload, $exception->getMessage());
+            }
+
             if ($engine->isStrict() || $this->isStrictThrowing()) {
                 throw $exception;
             }

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -32,6 +32,7 @@ use Kettasoft\Filterable\HttpIntegration\HeaderDrivenEngineSelector;
 use Kettasoft\Filterable\Foundation\Contracts\ShouldReturnQueryBuilder;
 use Kettasoft\Filterable\Exceptions\Contracts\ExceptionHandlerInterface;
 use Kettasoft\Filterable\Exceptions\RequestSourceIsNotSupportedException;
+use Kettasoft\Filterable\Support\Payload;
 
 class Filterable implements FilterableContext, Authorizable, Validatable, Commitable
 {
@@ -166,6 +167,12 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   protected $applied = [];
 
   /**
+   * Skipped payloads.
+   * @var array<Payload>
+   */
+  protected array $skipped = [];
+
+  /**
    * Create a new Filterable instance.
    * @param Request|null $request
    */
@@ -275,10 +282,58 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
    * @param Clause $clause
    * @return bool
    */
+  /**
+   * Commit applied clauses.
+   * @param string $key
+   * @param Clause $clause
+   * @return bool
+   */
   public function commit(string $key, Clause $clause): bool
   {
     $this->applied[$key] = $clause;
     return true;
+  }
+
+  /**
+   * Register a skipped payload.
+   * @param Payload $payload
+   * @param string|null $reason Optional reason for skipping
+   * @return bool
+   */
+  public function skip(Payload $payload, ?string $reason = null): bool
+  {
+    $this->skipped[] = [
+      'payload' => $payload,
+      'reason' => $reason,
+      'field' => $payload->field,
+      'value' => $payload->value,
+      'timestamp' => now(),
+    ];
+
+    return true;
+  }
+
+  /**
+   * Get all skipped payloads.
+   * @return array
+   */
+  public function skipped(?string $field = null): array
+  {
+    if ($field === null) {
+      return $this->skipped;
+    }
+
+    return array_filter($this->skipped, fn($item) => $item['field'] === $field);
+  }
+
+  /**
+   * Check if a specific field was skipped.
+   * @param string $field
+   * @return bool
+   */
+  public function hasSkipped(string $field): bool
+  {
+    return !empty($this->skipped($field));
   }
 
   /**

--- a/src/Support/AllowedFieldChecker.php
+++ b/src/Support/AllowedFieldChecker.php
@@ -11,7 +11,7 @@ class AllowedFieldChecker
    * Check if a field is allowed for filtering.
    * @param \Kettasoft\Filterable\Engines\Contracts\HasAllowedFieldChecker $context
    * @param mixed $field
-   * @throws \Kettasoft\Filterable\Exceptions\NotAllowedFieldException
+   * @throws \Kettasoft\Filterable\Engines\Exceptions\NotAllowedFieldException
    * @return bool
    */
   public static function check(HasAllowedFieldChecker $context, $field): bool
@@ -27,7 +27,7 @@ class AllowedFieldChecker
     }
 
     if ($context->isStrict()) {
-      throw new NotAllowedFieldException($field);
+      throw new NotAllowedFieldException($field, null);
     }
 
     return false;

--- a/src/Support/TreeBasedRelationsResolver.php
+++ b/src/Support/TreeBasedRelationsResolver.php
@@ -40,7 +40,7 @@ class TreeBasedRelationsResolver
     }
 
     if ($this->context->isStrict()) {
-      throw new NotAllowedFieldException($field);
+      throw new NotAllowedFieldException($field, null);
     }
 
     return false;


### PR DESCRIPTION
## Summary
Major refactoring of the Skip Strategy to track **which filters were skipped** and **why**. The new implementation stores `Payload` objects instead of raw clause strings, enabling better debugging, analytics, and filter execution flow visibility.

## Key Changes

### 1. SkipExecution Exception Refactoring

**Before:**
```php
class SkipExecution extends Exception
{
    public function __construct(string $message, protected mixed $clause = null)
}
```

**After:**
```php
class SkipExecution extends Exception
{
    public function __construct(string $message, protected ?Payload $payload = null)
}
```

**Benefits:**
- ✅ Store complete filter context (field, operator, value, raw value)
- ✅ Better debugging with structured data
- ✅ Enable analytics on skipped filters

### 2. Skipped Filters Tracking in Filterable

Added new property and methods to track skipped filters:

```php
class Filterable
{
    protected array $skipped = [];

    public function skip(Payload $payload, ?string $message = null): void
    {
        $this->skipped[] = [
            'payload' => $payload,
            'reason' => $reason,
            'field' => $payload->field,
            'value' => $payload->value,
            'timestamp' => now(),
        ];
        
        return true;
    }

    public function skipped(?string $key = null): mixed
    public function hasSkipped(string $key): bool
}
```

**Usage:**
```php
$filter = new ProductFilter($request);
$results = $filter->apply($query)->get();

// Check which filters were skipped
if ($filter->hasSkipped('price')) {
    $skipped = $filter->skipped('price');
    // ['reason' => 'Invalid operator: gt', 'payload' => {...}, 'timestamp' => ...]
}

// Get all skipped filters
$allSkipped = $filter->skipped();
```

### 3. Engine & Interface Updates

#### Skippable Interface
```php
interface Skippable
{
    // Before
    public function skip(string $message, mixed $payload = null): never;
    
    // After
    public function skip(Payload $payload, ?string $message = null): never;
}
```

#### Engine Implementation
```php
public function skip(Payload $payload, ?string $message = null): never
{
    $this->context->skip($payload, $message);
}
```

### 4. Exception Handler Integration

Updated `DefaultHandler` to automatically register skipped payloads:

```php
public function handle(Exception $exception, Engine $engine): void
{
    if ($this->hasSkipping($exception)) {
        // Register the skipped payload in the context
        if ($payload = $exception->getPayload()) {
            $engine->getContext()->skip($payload, $exception->getMessage());
        }
    }
    // ...
}
```

### 5. ✅ Attributes Updated

All 6 attributes that throw `SkipExecution` now pass `Payload`:

| Attribute | Example |
|-----------|---------|
| `SkipIf` | `throw new SkipExecution($this->message, $context->payload)` |
| `Between` | `throw new SkipExecution('...', $context->payload)` |
| `In` | `throw new SkipExecution('...', $context->payload)` |
| `MapValue` | `throw new SkipExecution('...', $context->payload)` |
| `Regex` | `throw new SkipExecution('...', $context->payload)` |
| `Authorize` | `throw new SkipExecution('...', $context->payload)` |

### 6. Exception Classes Updated

All skip-related exceptions now store `Payload`:

```php
// InvalidOperatorException
public function __construct(string $operator, Payload $payload)
{
    parent::__construct(
        sprintf('The operator [%s] is not allowed.', $operator),
        $payload
    );
}

// NotAllowedFieldException
// NotAllowedEmptyValueException
// (Similar updates)
```

## Impact Analysis

### Breaking Changes

⚠️ **BREAKING CHANGES:**

1. **SkipExecution signature changed**
   ```php
   // Before
   $exception->getClause(); // mixed
   
   // After
   $exception->getPayload(); // ?Payload
   ```

2. **Skippable interface signature changed**
   ```php
   // Before
   public function skip(string $message, mixed $payload = null): never;
   
   // After
   public function skip(Payload $payload, ?string $message = null): never;
   ```

3. **Custom exception handlers** that catch `SkipExecution` may need updates

### Migration Guide

```php
// Before
try {
    $filter->apply($query);
} catch (SkipExecution $e) {
    $clause = $e->getClause(); // string|null
}

// After
try {
    $filter->apply($query);
} catch (SkipExecution $e) {
    $payload = $e->getPayload(); // ?Payload
    if ($payload) {
        $field = $payload->field;
        $value = $payload->value;
    }
}

// Better: Use built-in tracking
$filter->apply($query);
if ($filter->hasSkipped('price')) {
    $info = $filter->skipped('price');
}
```

## New Features Enabled

### 1. Debugging Filter Execution
```php
$filter = new ProductFilter($request);
$results = $filter->apply($query)->get();

// See which filters were skipped
foreach ($filter->skipped() as $field => $info) {
    Log::debug("Filter '{$field}' skipped: {$info['reason']}");
}
```

### 2. API Response Enhancement
```php
return response()->json([
    'data' => $results,
    'meta' => [
        'applied_filters' => $filter->applied(),
        'skipped_filters' => $filter->skipped()
    ]
]);
```

## ✅ Testing

### Test Coverage
- ✅ Payload tracking in SkipExecution
- ✅ Filterable skip/skipped/hasSkipped methods
- ✅ All attributes correctly pass Payload
- ✅ Exception classes store Payload correctly
- ✅ Integration with DefaultHandler