### PR TITLE
refactor: extract runtime state into Context class

### DIFF
--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -2,38 +2,54 @@
 
 namespace Kettasoft\Filterable;
 
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\App;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Traits\Macroable;
-use Kettasoft\Filterable\Foundation\Invoker;
-use Kettasoft\Filterable\Contracts\Commitable;
-use Kettasoft\Filterable\Foundation\Resources;
-use Kettasoft\Filterable\Contracts\Validatable;
 use Kettasoft\Filterable\Contracts\Authorizable;
-use Kettasoft\Filterable\Sanitization\Sanitizer;
-use Illuminate\Contracts\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Contracts\Commitable;
+use Kettasoft\Filterable\Contracts\FilterableContext;
+use Kettasoft\Filterable\Contracts\Validatable;
+use Kettasoft\Filterable\Engines\Factory\EngineManager;
 use Kettasoft\Filterable\Engines\Foundation\Clause;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
-use Kettasoft\Filterable\Foundation\Sorting\Sorter;
-use Kettasoft\Filterable\Contracts\FilterableContext;
-use Kettasoft\Filterable\Engines\Factory\EngineManager;
-use Kettasoft\Filterable\Foundation\Contracts\Sortable;
-use Kettasoft\Filterable\Foundation\FilterableSettings;
-use Kettasoft\Filterable\Exceptions\MissingBuilderException;
-use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
 use Kettasoft\Filterable\Engines\Foundation\Executors\Executer;
+use Kettasoft\Filterable\Exceptions\Contracts\ExceptionHandlerInterface;
+use Kettasoft\Filterable\Exceptions\MissingBuilderException;
+use Kettasoft\Filterable\Exceptions\RequestSourceIsNotSupportedException;
 use Kettasoft\Filterable\Foundation\Contracts\FilterableProfile;
+use Kettasoft\Filterable\Foundation\Contracts\ShouldReturnQueryBuilder;
+use Kettasoft\Filterable\Foundation\Contracts\Sortable;
 use Kettasoft\Filterable\Foundation\Contracts\Sorting\Invokable;
 use Kettasoft\Filterable\Foundation\Events\Contracts\EventManager;
 use Kettasoft\Filterable\Foundation\Events\FilterableEventManager;
+use Kettasoft\Filterable\Foundation\FilterableSettings;
+use Kettasoft\Filterable\Foundation\Invoker;
+use Kettasoft\Filterable\Foundation\Resources;
+use Kettasoft\Filterable\Foundation\Runtime\Context;
+use Kettasoft\Filterable\Foundation\Sorting\Sorter;
+use Kettasoft\Filterable\Foundation\Traits\HandleFluentReturn;
 use Kettasoft\Filterable\HttpIntegration\HeaderDrivenEngineSelector;
-use Kettasoft\Filterable\Foundation\Contracts\ShouldReturnQueryBuilder;
-use Kettasoft\Filterable\Exceptions\Contracts\ExceptionHandlerInterface;
-use Kettasoft\Filterable\Exceptions\RequestSourceIsNotSupportedException;
+use Kettasoft\Filterable\Sanitization\Sanitizer;
 use Kettasoft\Filterable\Support\Payload;
 
+/**
+ * The main Filterable class that provides the core functionality for applying filters to Eloquent queries.
+ * 
+ * This class serves as the central point for managing filter execution, including:
+ * - Handling incoming requests and parsing filter data
+ * - Managing the filter engine and its execution
+ * - Providing hooks for authorization, validation, and committing applied clauses
+ * - Integrating with an event system to allow extensibility at various stages of the filtering process
+ * - Supporting sorting and caching mechanisms
+ * 
+ * The Filterable class is designed to be flexible and extensible, allowing developers to customize behavior through traits, events, and configuration.
+ * 
+ * @package Kettasoft\Filterable
+ * @property \Illuminate\Database\Eloquent\Builder $builder
+ */
 class Filterable implements FilterableContext, Authorizable, Validatable, Commitable
 {
   use Traits\InteractsWithFilterKey,
@@ -84,22 +100,24 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   protected $requestSource = 'query';
 
   /**
-   * The Builder instance.
-   * @var \Illuminate\Database\Eloquent\Builder
+   * Runtime context for this filterable instance.
+   * 
+   * Encapsulates all transient state that changes during filter execution:
+   * - Applied filter clauses
+   * - Skipped payloads
+   * - Parsed request data
+   * - Query builder instance
+   * - Cache key generator
+   * 
+   * @var Context
    */
-  protected Builder $builder;
+  protected Context $context;
 
   /**
    * Registered sanitizers to operate upon.
    * @var array
    */
   protected $sanitizers = [];
-
-  /**
-   * All received data from request.
-   * @var array
-   */
-  protected $data = [];
 
   /**
    * Specify which fields are allowed to be filtered.
@@ -161,19 +179,8 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   protected static EventManager $eventManager;
 
   /**
-   * Applied clauses.
-   * @var array
-   */
-  protected $applied = [];
-
-  /**
-   * Skipped payloads.
-   * @var array<Payload>
-   */
-  protected array $skipped = [];
-
-  /**
    * Create a new Filterable instance.
+   * 
    * @param Request|null $request
    */
   public function __construct(Request|null $request = null)
@@ -192,6 +199,7 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   {
     $this->request = $request ?: App::make(Request::class);
     $this->registerEventManager();
+    $this->context = new Context();
 
     // Fire initializing event
     $this->fireEvent('filterable.initializing', ['filterable' => $this]);
@@ -276,79 +284,77 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   }
 
   /**
-   * Commit clause.
-   *
-   * @param string $key
-   * @param Clause $clause
-   * @return bool
-   */
-  /**
    * Commit applied clauses.
-   * @param string $key
-   * @param Clause $clause
-   * @return bool
+   * 
+   * Records a filter clause that has been successfully applied to the query.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param string $key The field name or unique identifier for the clause
+   * @param Clause $clause The clause object representing the applied filter
+   * @return bool Always returns true to indicate success
    */
   public function commit(string $key, Clause $clause): bool
   {
-    $this->applied[$key] = $clause;
+    $this->context->commitClause($key, $clause);
     return true;
   }
 
   /**
    * Register a skipped payload.
-   * @param Payload $payload
-   * @param string|null $reason Optional reason for skipping
-   * @return bool
+   * 
+   * Records information about a filter that was skipped during execution.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param Payload $payload The payload that was skipped
+   * @param string|null $reason Optional explanation for why it was skipped
+   * @return bool Always returns true to indicate the skip was recorded
    */
   public function skip(Payload $payload, ?string $reason = null): bool
   {
-    $this->skipped[] = [
-      'payload' => $payload,
-      'reason' => $reason,
-      'field' => $payload->field,
-      'value' => $payload->value,
-      'timestamp' => now(),
-    ];
-
+    $this->context->skipPayload($payload, $reason);
     return true;
   }
 
   /**
    * Get all skipped payloads.
-   * @return array
+   * 
+   * Retrieves information about filters that were skipped, optionally filtered by field.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param string|null $field Optional field name to filter skipped payloads
+   * @return array All skipped payloads or filtered by field
    */
   public function skipped(?string $field = null): array
   {
-    if ($field === null) {
-      return $this->skipped;
-    }
-
-    return array_filter($this->skipped, fn($item) => $item['field'] === $field);
+    return $this->context->getSkipped($field);
   }
 
   /**
    * Check if a specific field was skipped.
-   * @param string $field
-   * @return bool
+   * 
+   * Determines whether any filters for the given field were skipped.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param string $field The field name to check
+   * @return bool True if the field has skipped filters, false otherwise
    */
   public function hasSkipped(string $field): bool
   {
-    return !empty($this->skipped($field));
+    return $this->context->hasSkipped($field);
   }
 
   /**
    * Get applied clauses.
-   *
-   * @param string $key
-   * @return array|Clause|null
+   * 
+   * Retrieves all applied clauses or a specific clause by key.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param string|null $key Optional field name to get a specific clause
+   * @return array|Clause|null All clauses if key is null, specific clause otherwise, or null if not found
    */
   public function applied($key = null)
   {
-    if (!$key) {
-      return $this->applied;
-    }
-
-    return $this->applied[$key] ?? null;
+    return $this->context->getApplied($key);
   }
 
   /**
@@ -401,7 +407,7 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
 
       $builder = $this->initQueryBuilderInstance($builder);
 
-      $this->builder = $this->initially($builder);
+      $this->context->setBuilder($this->initially($builder));
 
       $builder = Executer::execute($this->engine, $builder);
 
@@ -579,8 +585,8 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
     if ($builder)
       return $builder;
 
-    if (isset($this->builder))
-      return $this->builder;
+    if ($this->context->hasBuilder())
+      return $this->context->getBuilder();
 
     if ($this->model instanceof Model) {
       return $this->model->query();
@@ -729,13 +735,19 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
 
   /**
    * Set manual data injection.
-   * @param array $data
-   * @param bool $override
-   * @return static
+   * 
+   * Manually sets filter data, optionally merging with existing data.
+   * Useful for programmatically applying filters without HTTP request.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param array $data The filter data to set
+   * @param bool $override If true, replaces existing data; if false, merges with existing
+   * @return static Returns $this for method chaining
    */
   public function setData(array $data, bool $override = true): static
   {
-    $this->data = $override ? $data : array_merge($this->data, $data);
+    $currentData = $this->context->getData();
+    $this->context->setData($override ? $data : array_merge($currentData, $data));
     return $this;
   }
 
@@ -774,21 +786,30 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   }
 
   /**
-   * Parse incomming data from request.
+   * Parse incoming request data.
+   * 
+   * Extracts filter parameters from the HTTP request and stores them in runtime state.
+   * 
    * @return void
    */
   private function parseIncomingRequestData()
   {
-    $this->data = [...$this->request->all(), ...$this->request->json()->all()];
+    $this->context->setData([...$this->request->all(), ...$this->request->json()->all()]);
   }
 
   /**
-   * Get current data.
-   * @return array
+   * Get current filter data.
+   * 
+   * Returns the filter parameters extracted from the request.
+   * If a filter key is set, returns data scoped to that key.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @return mixed The filter data array or scoped data
    */
   public function getData(): mixed
   {
-    return $this->filterKey === null ? $this->data : $this->data[$this->filterKey] ?? $this->data;
+    $data = $this->context->getData();
+    return $this->filterKey === null ? $data : ($data[$this->filterKey] ?? $data);
   }
 
   /**
@@ -957,21 +978,29 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
 
   /**
    * Get registered filter builder.
-   * @return Builder
+   * 
+   * Returns the Eloquent query builder that filters are being applied to.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @return Builder The query builder instance
    */
   public function getBuilder(): Builder
   {
-    return $this->builder;
+    return $this->context->getBuilder();
   }
 
   /**
    * Set a new builder.
-   * @param Builder $builder
-   * @return static
+   * 
+   * Attaches an Eloquent query builder to this filterable instance.
+   * This is a wrapper method that delegates to the runtime state.
+   * 
+   * @param Builder $builder The query builder to attach
+   * @return static Returns $this for method chaining
    */
   public function setBuilder(Builder $builder): static
   {
-    $this->builder = $builder;
+    $this->context->setBuilder($builder);
     return $this;
   }
 
@@ -982,7 +1011,7 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
    */
   public function autoSetAllowedFieldsFromModel(bool $override = false): static
   {
-    $fillable = $this->builder->getModel()->getFillable();
+    $fillable = $this->context->getBuilder()->getModel()->getFillable();
     $this->allowedFields = $override ? $fillable : array_merge($this->allowedFields, $fillable);
 
     return $this;
@@ -1031,12 +1060,33 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   }
 
   /**
-   * Dynamically retrieve attributes from the request.
-   * @param mixed $property
-   * @return mixed
+   * Dynamically retrieve attributes.
+   * 
+   * Provides backward compatibility for accessing runtime state properties
+   * (builder, data, applied, skipped) as if they were direct properties.
+   * 
+   * @param mixed $property The property name
+   * @return mixed The property value
    */
   public function __get($property): mixed
   {
+    // Backward compatibility: map state properties to state object
+    if ($property === 'builder') {
+      return $this->context->getBuilder();
+    }
+
+    if ($property === 'data') {
+      return $this->context->getData();
+    }
+
+    if ($property === 'applied') {
+      return $this->context->getApplied();
+    }
+
+    if ($property === 'skipped') {
+      return $this->context->getSkipped();
+    }
+
     if (property_exists($this, $property)) {
       return $this->{$property};
     }

--- a/src/Foundation/Runtime/Context.php
+++ b/src/Foundation/Runtime/Context.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace Kettasoft\Filterable\Foundation\Runtime;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Engines\Foundation\Clause;
+use Kettasoft\Filterable\Support\Payload;
+
+/**
+ * Context - Manages transient runtime state for Filterable instances.
+ * 
+ * This class encapsulates all runtime state that is specific to a single filter execution.
+ * Unlike configuration properties (filters, allowed fields, etc.), runtime state is:
+ * - Transient: Only valid during a single filter operation
+ * - Mutable: Changes as filters are applied
+ * - Non-shareable: Should not be shared between cloned instances
+ * 
+ * The state includes:
+ * - Applied filter clauses (tracking what filters were executed)
+ * - Skipped payloads (tracking what filters were ignored and why)
+ * - Parsed request data (the actual filter parameters from the request)
+ * - Query builder instance (the Eloquent builder being filtered)
+ * - Cache key generator (custom cache key generation logic)
+ * 
+ * By isolating runtime state in a dedicated class:
+ * 1. Clone operations become simpler (just create new state instance)
+ * 2. Testing becomes easier (can mock or inspect state independently)
+ * 3. State management is centralized and explicit
+ * 4. Following Single Responsibility Principle
+ * 
+ * @package Kettasoft\Filterable\Foundation
+ * @since 3.x
+ */
+class Context
+{
+  /**
+   * Applied filter clauses.
+   * 
+   * Stores all successfully applied filter clauses keyed by their field names.
+   * This allows tracking which filters were actually applied to the query.
+   * 
+   * @var array<string, Clause>
+   */
+  protected array $applied = [];
+
+  /**
+   * Skipped payloads with metadata.
+   * 
+   * Stores information about filters that were skipped during execution,
+   * including the reason for skipping, field name, value, and timestamp.
+   * Useful for debugging and understanding why certain filters weren't applied.
+   * 
+   * @var array<array{payload: Payload, reason: string|null, field: string, value: mixed, timestamp: \Carbon\Carbon}>
+   */
+  protected array $skipped = [];
+
+  /**
+   * Parsed request data.
+   * 
+   * Contains the filter parameters extracted from the HTTP request.
+   * This is the sanitized and validated data that will be used for filtering.
+   * 
+   * @var array
+   */
+  protected array $data = [];
+
+  /**
+   * The query builder instance.
+   * 
+   * Holds the Eloquent query builder or relation that filters are being applied to.
+   * Initially null, set when apply() is called.
+   * Can be a Builder, Relation, or any object implementing BuilderContract.
+   * 
+   * @var \Illuminate\Database\Eloquent\Builder|null
+   */
+  protected ?Builder $builder = null;
+
+  /**
+   * Cache key generator callback or instance.
+   * 
+   * Optional custom function or CacheKeyGenerator instance for generating cache keys.
+   * If not set, the default cache key generation logic is used.
+   * 
+   * @var callable|\Kettasoft\Filterable\Foundation\Caching\CacheKeyGenerator|null
+   */
+  protected $cacheKeyGenerator = null;
+
+  /**
+   * Commit a clause as applied.
+   * 
+   * Records a filter clause that has been successfully applied to the query.
+   * This is called by the engine after a filter is executed.
+   * 
+   * @param string $key The field name or unique identifier for the clause
+   * @param Clause $clause The clause object representing the applied filter
+   * @return void
+   */
+  public function commitClause(string $key, Clause $clause): void
+  {
+    $this->applied[$key] = $clause;
+  }
+
+  /**
+   * Register a skipped payload.
+   * 
+   * Records information about a filter that was skipped during execution.
+   * Captures the payload, reason for skipping, and a timestamp for debugging.
+   * 
+   * @param Payload $payload The payload that was skipped
+   * @param string|null $reason Optional explanation for why it was skipped
+   * @return void
+   */
+  public function skipPayload(Payload $payload, ?string $reason = null): void
+  {
+    $this->skipped[] = [
+      'payload' => $payload,
+      'reason' => $reason,
+      'field' => $payload->field,
+      'value' => $payload->value,
+      'timestamp' => now(),
+    ];
+  }
+
+  /**
+   * Get applied clauses.
+   * 
+   * Retrieves all applied clauses or a specific clause by key.
+   * 
+   * @param string|null $key Optional field name to get a specific clause
+   * @return mixed All clauses if key is null, specific clause otherwise, or null if not found
+   */
+  public function getApplied(?string $key = null): mixed
+  {
+    if ($key === null) {
+      return $this->applied;
+    }
+
+    return $this->applied[$key] ?? null;
+  }
+
+  /**
+   * Get skipped payloads.
+   * 
+   * Retrieves all skipped payloads or filters by field name.
+   * 
+   * @param string|null $field Optional field name to filter skipped payloads
+   * @return array All skipped payloads or filtered by field
+   */
+  public function getSkipped(?string $field = null): array
+  {
+    if ($field === null) {
+      return $this->skipped;
+    }
+
+    return array_filter($this->skipped, fn($item) => $item['field'] === $field);
+  }
+
+  /**
+   * Check if a field was skipped.
+   * 
+   * Determines whether any filters for the given field were skipped.
+   * 
+   * @param string $field The field name to check
+   * @return bool True if the field has skipped filters, false otherwise
+   */
+  public function hasSkipped(string $field): bool
+  {
+    return !empty($this->getSkipped($field));
+  }
+
+  /**
+   * Set parsed request data.
+   * 
+   * Updates the filter parameters from the request.
+   * 
+   * @param array $data The parsed filter data
+   * @return void
+   */
+  public function setData(array $data): void
+  {
+    $this->data = $data;
+  }
+
+  /**
+   * Get parsed request data.
+   * 
+   * Returns the filter parameters that were extracted from the request.
+   * 
+   * @return array The filter data
+   */
+  public function getData(): array
+  {
+    return $this->data;
+  }
+
+  /**
+   * Set the query builder instance.
+   * 
+   * Attaches an Eloquent query builder or relation to this state.
+   * 
+   * @param \Illuminate\Database\Eloquent\Builder $builder The query builder or relation to set
+   * @return void
+   */
+  public function setBuilder(Builder $builder): void
+  {
+    $this->builder = $builder;
+  }
+
+  /**
+   * Get the query builder instance.
+   * 
+   * Returns the currently attached query builder or relation
+   * 
+   * @return \Illuminate\Database\Eloquent\Builder
+   */
+  public function getBuilder(): Builder
+  {
+    return $this->builder;
+  }
+
+  /**
+   * Check if builder is set.
+   * 
+   * Determines whether a query builder has been attached to this state.
+   * 
+   * @return bool True if builder exists, false otherwise
+   */
+  public function hasBuilder(): bool
+  {
+    return $this->builder !== null;
+  }
+
+  /**
+   * Set cache key generator callback or instance.
+   * 
+   * Assigns a custom function or CacheKeyGenerator for generating cache keys.
+   * 
+   * @param callable|\Kettasoft\Filterable\Foundation\Caching\CacheKeyGenerator|null $generator The generator function/instance or null to unset
+   * @return void
+   */
+  public function setCacheKeyGenerator($generator): void
+  {
+    $this->cacheKeyGenerator = $generator;
+  }
+
+  /**
+   * Get cache key generator callback or instance.
+   * 
+   * Returns the custom cache key generator, if set.
+   * 
+   * @return callable|\Kettasoft\Filterable\Foundation\Caching\CacheKeyGenerator|null The generator function/instance or null
+   */
+  public function getCacheKeyGenerator()
+  {
+    return $this->cacheKeyGenerator;
+  }
+
+  /**
+   * Check if cache key generator is set.
+   * 
+   * Determines whether a custom cache key generator has been configured.
+   * 
+   * @return bool True if generator exists, false otherwise
+   */
+  public function hasCacheKeyGenerator(): bool
+  {
+    return $this->cacheKeyGenerator !== null;
+  }
+
+  /**
+   * Reset all runtime state.
+   * 
+   * Clears all transient data, returning the state to its initial condition.
+   * Useful for reusing a Filterable instance or after cloning.
+   * 
+   * @return void
+   */
+  public function reset(): void
+  {
+    $this->applied = [];
+    $this->skipped = [];
+    $this->data = [];
+    $this->builder = null;
+    $this->cacheKeyGenerator = null;
+  }
+
+  /**
+   * Create a snapshot of current state.
+   * 
+   * Captures the current runtime state for later inspection or restoration.
+   * Useful for debugging or implementing state rollback mechanisms.
+   * 
+   * @return array Associative array containing all state data
+   */
+  public function snapshot(): array
+  {
+    return [
+      'applied' => $this->applied,
+      'skipped' => $this->skipped,
+      'data' => $this->data,
+      'builder' => $this->builder,
+      'cacheKeyGenerator' => $this->cacheKeyGenerator,
+    ];
+  }
+
+  /**
+   * Restore state from a snapshot.
+   * 
+   * Replaces current state with data from a previous snapshot.
+   * Useful for implementing undo/rollback functionality.
+   * 
+   * @param array $snapshot Previously captured state snapshot
+   * @return void
+   */
+  public function restore(array $snapshot): void
+  {
+    $this->applied = $snapshot['applied'] ?? [];
+    $this->skipped = $snapshot['skipped'] ?? [];
+    $this->data = $snapshot['data'] ?? [];
+    $this->builder = $snapshot['builder'] ?? null;
+    $this->cacheKeyGenerator = $snapshot['cacheKeyGenerator'] ?? null;
+  }
+}

--- a/src/Traits/HasFilterableCache.php
+++ b/src/Traits/HasFilterableCache.php
@@ -67,13 +67,6 @@ trait HasFilterableCache
     protected $cacheWhenCallback = null;
 
     /**
-     * Cache key generator instance
-     *
-     * @var CacheKeyGenerator|null
-     */
-    protected ?CacheKeyGenerator $cacheKeyGenerator = null;
-
-    /**
      * Enable caching with optional TTL
      *
      * @param DateTimeInterface|int|null $ttl Time to live in seconds or DateTimeInterface
@@ -333,17 +326,20 @@ trait HasFilterableCache
     }
 
     /**
-     * Get cache key generator instance
+     * Get or create cache key generator
      *
      * @return CacheKeyGenerator
      */
     protected function getCacheKeyGenerator(): CacheKeyGenerator
     {
-        if ($this->cacheKeyGenerator === null) {
-            $this->cacheKeyGenerator = new CacheKeyGenerator();
+        $generator = $this->context->getCacheKeyGenerator();
+
+        if ($generator === null) {
+            $generator = new CacheKeyGenerator();
+            $this->context->setCacheKeyGenerator($generator);
         }
 
-        return $this->cacheKeyGenerator;
+        return $generator;
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR introduces a new `Context` class to encapsulate all transient runtime state in the Filterable system, improving code organization and maintainability.

## Motivation

Previously, runtime state properties (`applied`, `skipped`, `data`, `builder`, `cacheKeyGenerator`) were mixed with configuration properties directly in the `Filterable` class. This made it:
- Harder to distinguish between configuration and runtime state
- More complex to implement cloning operations
- Difficult to test state management independently

## Changes

### New Class: `Context`
- **Location:** `Foundation/Runtime/Context.php`
- **Purpose:** Manages all transient runtime state for a single filter execution
- **Properties:**
  - `$applied` - Tracks successfully applied filter clauses
  - `$skipped` - Tracks skipped payloads with metadata
  - `$data` - Parsed request filter parameters
  - `$builder` - Eloquent query builder instance
  - `$cacheKeyGenerator` - Custom cache key generation logic

### Modified: `Filterable` Class
- Replaced individual state properties with single `$context` instance
- All state-related methods now delegate to `Context.`
- Methods updated:
  - `commit()` → `$context->commitClause()`
  - `skip()` → `$context->skipPayload()`
  - `applied()` → `$context->getApplied()`
  - `skipped()` → `$context->getSkipped()`
  - `setData()` / `getData()` → `$context->setData()` / `$context->getData()`
  - `setBuilder()` / `getBuilder()` → `$context->setBuilder()` / `$context->getBuilder()`

### Backward Compatibility
- Added `__get()` magic method to maintain BC for direct property access
- Accessing `$this->builder`, `$this->data`, etc. still works transparently

### Cache Integration
- Updated `HasFilterableCache` trait to use `$context->getCacheKeyGenerator().`
- No breaking changes to caching API

## Benefits

✅ **Single Responsibility:** State management is now centralized
✅ **Easier Testing:** Context can be mocked/inspected independently  
✅ **Simpler Cloning:** Just reset `$context` instead of multiple properties
✅ **Better Organization:** Clear separation between config and runtime state
✅ **Future-Proof:** Easy to add new state properties without cluttering Filterable

## Testing

- ✅ All tests passing
- ✅ No breaking changes
- ✅ Backward compatibility maintained via `__get()` magic method

---

**Type:** Refactoring
**Breaking Changes:** None
**Tests:** all tests passing ✅