### PR TITLE
Add dedicated exception handling for filter method conflicts

### DIFF
--- a/docs/engines/invokable/index.md
+++ b/docs/engines/invokable/index.md
@@ -147,6 +147,13 @@ If `$mentors` is empty or not defined, the engine automatically matches request 
 'created_at'  → calls createdAt()
 ```
 
+::: warning Reserved Method Names
+Filter methods must not resolve to a method already defined by the base
+`Filterable` class, such as `apply`, `filter`, or `getBuilder`. The engine
+throws a `FilterableMethodConflictException` when a conflict is detected. Use
+`$mentors` to map the request key to a unique filter method name.
+:::
+
 ---
 
 ## Attribute Pipeline

--- a/src/Engines/Invokable.php
+++ b/src/Engines/Invokable.php
@@ -2,17 +2,17 @@
 
 namespace Kettasoft\Filterable\Engines;
 
-use Illuminate\Support\Str;
-use Kettasoft\Filterable\Filterable;
 use Illuminate\Contracts\Database\Eloquent\Builder;
-use Kettasoft\Filterable\Support\Payload;
+use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
+use Kettasoft\Filterable\Engines\Foundation\Attributes\AttributeContext;
+use Kettasoft\Filterable\Engines\Foundation\Attributes\AttributePipeline;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
 use Kettasoft\Filterable\Engines\Foundation\PayloadFactory;
 use Kettasoft\Filterable\Engines\Foundation\Parsers\Dissector;
-use Kettasoft\Filterable\Engines\Foundation\Attributes\AttributeContext;
-use Kettasoft\Filterable\Engines\Foundation\Attributes\AttributePipeline;
-use Kettasoft\Filterable\Engines\Foundation\Attributes\AttributeRegistry;
+use Kettasoft\Filterable\Exceptions\FilterableMethodConflictException;
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Support\Payload;
 
 class Invokable extends Engine
 {
@@ -43,19 +43,19 @@ class Invokable extends Engine
     $this->context->setAllowedFields($this->context->getFilterAttributes());
 
     foreach ($this->context->getFilterAttributes() as $filter) {
-      $this->attempt(function () use ($filter) {
+      $method = $this->getMethodName($filter);
+
+      // Check for method name conflicts with Filterable core methods BEFORE attempt.
+      if (method_exists(Filterable::class, $method)) {
+        throw new FilterableMethodConflictException($method);
+      }
+
+      $this->attempt(function () use ($filter, $method) {
         $dissector = Dissector::parse($this->context->getRequest()->get($filter), $this->defaultOperator());
 
         $payload = new Payload($filter, $dissector->operator, $this->sanitizeValue($filter, $dissector->value), $dissector->value);
 
         $payload = (new PayloadFactory($this))->make($payload);
-
-        $method = $this->getMethodName($filter);
-
-        // Check for method name conflicts with Filterable core methods.
-        if (method_exists(Filterable::class, $method)) {
-          throw new \RuntimeException(sprintf("Filter method [%s] conflicts with core Filterable method.", [$method]));
-        }
 
         $this->applyFilterMethod($filter, $method, $payload);
 

--- a/src/Engines/Invokable.php
+++ b/src/Engines/Invokable.php
@@ -45,7 +45,7 @@ class Invokable extends Engine
     foreach ($this->context->getFilterAttributes() as $filter) {
       $method = $this->getMethodName($filter);
 
-      // Check for method name conflicts with Filterable core methods BEFORE attempt.
+      // Conflicts are configuration errors and must not be swallowed in non-strict mode.
       if (method_exists(Filterable::class, $method)) {
         throw new FilterableMethodConflictException($method);
       }

--- a/src/Exceptions/FilterableMethodConflictException.php
+++ b/src/Exceptions/FilterableMethodConflictException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+class FilterableMethodConflictException extends StrictnessException
+{
+  /**
+   * Create a new exception instance.
+   *
+   * @param string $method The conflicting method name.
+   */
+  public function __construct(string $method)
+  {
+    parent::__construct(sprintf("Filter method [%s] conflicts with core Filterable method.", $method));
+  }
+}

--- a/tests/Unit/Engines/InvokableEngineTest.php
+++ b/tests/Unit/Engines/InvokableEngineTest.php
@@ -3,6 +3,7 @@
 namespace Kettasoft\Filterable\Tests\Unit\Engines;
 
 use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Exceptions\FilterableMethodConflictException;
 use Kettasoft\Filterable\Tests\TestCase;
 use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Tests\Models\Post;
@@ -988,23 +989,16 @@ class InvokableEngineTest extends TestCase
    */
   public function it_throws_exception_when_filter_method_conflicts_with_core_filterable_methods()
   {
-    $this->expectException(\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException::class);
+    $this->expectException(FilterableMethodConflictException::class);
 
-    Post::truncate();
-    Post::factory()->create(['status' => 'active']);
-
-    // Using 'apply' as filter name which will map to 'apply' method (conflict)
     request()->merge([
       'apply' => 'test'
     ]);
 
     $filter = new class extends Filterable {
       protected $filters = ['apply'];
-
-      // This will cause a conflict because Filterable already has apply() method
     };
 
-    // Should throw FilterableMethodConflictException
     Post::filter($filter)->get();
   }
 
@@ -1023,9 +1017,6 @@ class InvokableEngineTest extends TestCase
     ];
 
     foreach ($coreMethodsThatShouldConflict as $coreMethod) {
-      Post::truncate();
-      Post::factory()->create(['status' => 'active']);
-
       request()->merge([
         $coreMethod => 'test_value'
       ]);
@@ -1044,7 +1035,7 @@ class InvokableEngineTest extends TestCase
         Post::filter($filter)->get();
 
         $this->fail("Expected FilterableMethodConflictException for method: {$coreMethod}");
-      } catch (\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException $e) {
+      } catch (FilterableMethodConflictException $e) {
         $this->assertStringContainsString($coreMethod, $e->getMessage());
         $this->assertStringContainsString('conflicts with core Filterable method', $e->getMessage());
       }
@@ -1056,7 +1047,7 @@ class InvokableEngineTest extends TestCase
    */
   public function it_allows_filter_methods_that_do_not_conflict()
   {
-    Post::query()->delete(); // Use delete instead of truncate to respect RefreshDatabase
+    Post::query()->delete();
 
     Post::factory()->create(['status' => 'active', 'title' => 'Active Post']);
     Post::factory()->create(['status' => 'pending', 'title' => 'Pending Post']);
@@ -1065,7 +1056,6 @@ class InvokableEngineTest extends TestCase
       'custom_status' => 'active'
     ]);
 
-    // This should NOT throw an exception because 'customStatus' is not a core method
     $filter = new class extends Filterable {
       protected $filters = ['custom_status'];
 
@@ -1087,13 +1077,11 @@ class InvokableEngineTest extends TestCase
    */
   public function it_properly_formats_exception_message()
   {
-    try {
-      throw new \Kettasoft\Filterable\Exceptions\FilterableMethodConflictException('testMethod');
-    } catch (\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException $e) {
-      $this->assertEquals(
-        'Filter method [testMethod] conflicts with core Filterable method.',
-        $e->getMessage()
-      );
-    }
+    $exception = new FilterableMethodConflictException('testMethod');
+
+    $this->assertSame(
+      'Filter method [testMethod] conflicts with core Filterable method.',
+      $exception->getMessage()
+    );
   }
 }

--- a/tests/Unit/Engines/InvokableEngineTest.php
+++ b/tests/Unit/Engines/InvokableEngineTest.php
@@ -982,4 +982,118 @@ class InvokableEngineTest extends TestCase
     $this->assertEquals('active', $posts->first()->status);
     $this->assertGreaterThanOrEqual(100, $posts->first()->views);
   }
+
+  /**
+   * @test
+   */
+  public function it_throws_exception_when_filter_method_conflicts_with_core_filterable_methods()
+  {
+    $this->expectException(\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException::class);
+
+    Post::truncate();
+    Post::factory()->create(['status' => 'active']);
+
+    // Using 'apply' as filter name which will map to 'apply' method (conflict)
+    request()->merge([
+      'apply' => 'test'
+    ]);
+
+    $filter = new class extends Filterable {
+      protected $filters = ['apply'];
+
+      // This will cause a conflict because Filterable already has apply() method
+    };
+
+    // Should throw FilterableMethodConflictException
+    Post::filter($filter)->get();
+  }
+
+  /**
+   * @test
+   */
+  public function it_throws_exception_for_multiple_core_method_conflicts()
+  {
+    $coreMethodsThatShouldConflict = [
+      'apply',
+      'filter',
+      'getData',
+      'getModel',
+      'getBuilder',
+      'getEngine'
+    ];
+
+    foreach ($coreMethodsThatShouldConflict as $coreMethod) {
+      Post::truncate();
+      Post::factory()->create(['status' => 'active']);
+
+      request()->merge([
+        $coreMethod => 'test_value'
+      ]);
+
+      try {
+        $filter = new class($coreMethod) extends Filterable {
+          protected $filters = [];
+
+          public function __construct($method)
+          {
+            $this->filters = [$method];
+            parent::__construct();
+          }
+        };
+
+        Post::filter($filter)->get();
+
+        $this->fail("Expected FilterableMethodConflictException for method: {$coreMethod}");
+      } catch (\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException $e) {
+        $this->assertStringContainsString($coreMethod, $e->getMessage());
+        $this->assertStringContainsString('conflicts with core Filterable method', $e->getMessage());
+      }
+    }
+  }
+
+  /**
+   * @test
+   */
+  public function it_allows_filter_methods_that_do_not_conflict()
+  {
+    Post::query()->delete(); // Use delete instead of truncate to respect RefreshDatabase
+
+    Post::factory()->create(['status' => 'active', 'title' => 'Active Post']);
+    Post::factory()->create(['status' => 'pending', 'title' => 'Pending Post']);
+
+    request()->merge([
+      'custom_status' => 'active'
+    ]);
+
+    // This should NOT throw an exception because 'customStatus' is not a core method
+    $filter = new class extends Filterable {
+      protected $filters = ['custom_status'];
+
+      public function customStatus(Payload $payload)
+      {
+        $this->builder->where('status', $payload->value);
+      }
+    };
+
+    $posts = Post::filter($filter)->get();
+
+    $this->assertCount(1, $posts);
+    $this->assertEquals('active', $posts->first()->status);
+    $this->assertEquals('Active Post', $posts->first()->title);
+  }
+
+  /**
+   * @test
+   */
+  public function it_properly_formats_exception_message()
+  {
+    try {
+      throw new \Kettasoft\Filterable\Exceptions\FilterableMethodConflictException('testMethod');
+    } catch (\Kettasoft\Filterable\Exceptions\FilterableMethodConflictException $e) {
+      $this->assertEquals(
+        'Filter method [testMethod] conflicts with core Filterable method.',
+        $e->getMessage()
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Detect filter methods that conflict with core `Filterable` methods and report them using a dedicated exception.

## Changes

- Add `FilterableMethodConflictException`
- Detect conflicts with methods such as `apply`, `filter`, and `getBuilder`
- Perform conflict detection outside `attempt()` so configuration errors are never silently swallowed
- Preserve the current Payload-based filtering pipeline
- Document reserved method names and `$mentors` as the recommended alternative
- Add tests for single and multiple method conflicts
- Verify that non-conflicting filter methods continue working
- Add coverage for the exception message