### PR TITLE
Introduce backend-neutral driver foundation and database driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Backend-independent comparison and logical-group operations.
+- A driver contract and manager with an initial Eloquent database driver.
+
 ## [3.0.0] - 2026-09-10
 
 ### Added

--- a/config/filterable.php
+++ b/config/filterable.php
@@ -78,6 +78,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Filter Drivers
+    |--------------------------------------------------------------------------
+    |
+    | Drivers translate backend-independent filter operations into queries for
+    | a concrete backend. The database driver remains the default and preserves
+    | the package's existing Eloquent behavior.
+    |
+    */
+    'default_driver' => 'database',
+
+    'drivers' => [
+        'database' => \Kettasoft\Filterable\Drivers\DatabaseDriver::class,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Filter Profiles
     |--------------------------------------------------------------------------
     | Configure filter profiles for different contexts or models.

--- a/src/Drivers/Contracts/Driver.php
+++ b/src/Drivers/Contracts/Driver.php
@@ -11,6 +11,13 @@ interface Driver
 {
     /**
      * Apply an operation and return the resulting backend query object.
+     *
+     * Each driver is responsible for validating that the supplied query is a
+     * supported target and for translating the operation into backend calls.
+     *
+     * @param Operation $operation Backend-independent instruction to apply.
+     * @param object $query Backend query object that receives the instruction.
+     * @return object The original or replacement backend query object.
      */
     public function apply(Operation $operation, object $query): object;
 }

--- a/src/Drivers/Contracts/Driver.php
+++ b/src/Drivers/Contracts/Driver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kettasoft\Filterable\Drivers\Contracts;
+
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+
+/**
+ * Translates backend-independent operations for a backend query object.
+ */
+interface Driver
+{
+    /**
+     * Apply an operation and return the resulting backend query object.
+     */
+    public function apply(Operation $operation, object $query): object;
+}

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Kettasoft\Filterable\Drivers;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Exceptions\InvalidDriverTargetException;
+use Kettasoft\Filterable\Exceptions\UnsupportedOperationException;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Operations\Group;
+use Kettasoft\Filterable\Support\Payload;
+use Kettasoft\Filterable\Engines\Foundation\Operators\OperatorResolver;
+
+class DatabaseDriver implements Driver
+{
+    /**
+     * The operator resolver instance.
+     *
+     * @var OperatorResolver
+     */
+    private OperatorResolver $operators;
+
+    /**
+     * Create a new database driver instance.
+     * 
+     * @param OperatorResolver|null $operators
+     */
+    public function __construct(?OperatorResolver $operators = null)
+    {
+        $this->operators = $operators ?? OperatorResolver::fromConfig();
+    }
+
+    /**
+     * Apply an operation to a query.
+     *
+     * @param Operation $operation
+     * @param object $query
+     *
+     * @return object
+     *
+     * @throws InvalidDriverTargetException
+     * @throws UnsupportedOperationException
+     */
+    public function apply(Operation $operation, object $query): object
+    {
+        if (! $query instanceof Builder) {
+            throw new InvalidDriverTargetException('database', $query, Builder::class);
+        }
+
+        return $this->applyToBuilder($operation, $query);
+    }
+
+    /**
+     * Apply an operation to a query builder.
+     *
+     * @param Operation $operation
+     * @param Builder $builder
+     *
+     * @return Builder
+     *
+     * @throws UnsupportedOperationException
+     */
+    private function applyToBuilder(Operation $operation, Builder $builder): Builder
+    {
+        if ($operation instanceof Comparison) {
+            return $this->applyComparison($operation, $builder);
+        }
+
+        if ($operation instanceof Group) {
+            return $this->applyGroup($operation, $builder);
+        }
+
+        throw new UnsupportedOperationException('database', $operation);
+    }
+
+    private function applyComparison(Comparison $operation, Builder $builder): Builder
+    {
+        if (str_contains($operation->field(), '.')) {
+            return $this->applyRelationalComparison($operation, $builder);
+        }
+
+        return $this->applyOperator($operation, $builder);
+    }
+
+    private function applyRelationalComparison(Comparison $operation, Builder $builder): Builder
+    {
+        $segments = explode('.', $operation->field());
+        $field = array_pop($segments);
+        $relation = implode('.', $segments);
+
+        return $builder->whereHas($relation, function (Builder $query) use ($operation, $field): Builder {
+            return $this->applyOperator(
+                new Comparison($field, $operation->operator(), $operation->value()),
+                $query
+            );
+        });
+    }
+
+    private function applyGroup(Group $group, Builder $builder): Builder
+    {
+        if ($group->operations() === []) {
+            return $builder;
+        }
+
+        return $builder->where(function (Builder $query) use ($group): void {
+            foreach ($group->operations() as $index => $operation) {
+                $method = $index === 0 || $group->boolean() === 'and' ? 'where' : 'orWhere';
+
+                $query->{$method}(function (Builder $nested) use ($operation): void {
+                    $this->applyToBuilder($operation, $nested);
+                });
+            }
+        });
+    }
+
+    private function applyOperator(Comparison $operation, Builder $builder): Builder
+    {
+        $payload = new Payload(
+            $operation->field(),
+            $operation->operator(),
+            $operation->value(),
+            $operation->value(),
+        );
+
+        return $this->operators->resolve($operation->operator())->apply($builder, $payload);
+    }
+}

--- a/src/Drivers/DatabaseDriver.php
+++ b/src/Drivers/DatabaseDriver.php
@@ -23,8 +23,10 @@ class DatabaseDriver implements Driver
 
     /**
      * Create a new database driver instance.
-     * 
-     * @param OperatorResolver|null $operators
+     *
+     * @param OperatorResolver|null $operators Resolver used to translate
+     *     comparison operators into Eloquent query operations. When omitted,
+     *     the resolver is built from the package configuration.
      */
     public function __construct(?OperatorResolver $operators = null)
     {
@@ -32,15 +34,14 @@ class DatabaseDriver implements Driver
     }
 
     /**
-     * Apply an operation to a query.
+     * Apply a backend-independent operation to an Eloquent query.
      *
-     * @param Operation $operation
-     * @param object $query
+     * @param Operation $operation Instruction to translate into Eloquent calls.
+     * @param object $query Query object expected to implement Eloquent's Builder contract.
+     * @return object The filtered Eloquent builder.
      *
-     * @return object
-     *
-     * @throws InvalidDriverTargetException
-     * @throws UnsupportedOperationException
+     * @throws InvalidDriverTargetException When the query is not an Eloquent builder.
+     * @throws UnsupportedOperationException When the operation type is not supported.
      */
     public function apply(Operation $operation, object $query): object
     {
@@ -52,14 +53,13 @@ class DatabaseDriver implements Driver
     }
 
     /**
-     * Apply an operation to a query builder.
+     * Dispatch an operation to its database-specific application method.
      *
-     * @param Operation $operation
-     * @param Builder $builder
+     * @param Operation $operation Instruction being applied.
+     * @param Builder $builder Eloquent builder receiving the instruction.
+     * @return Builder The updated Eloquent builder.
      *
-     * @return Builder
-     *
-     * @throws UnsupportedOperationException
+     * @throws UnsupportedOperationException When no database implementation exists.
      */
     private function applyToBuilder(Operation $operation, Builder $builder): Builder
     {
@@ -74,6 +74,13 @@ class DatabaseDriver implements Driver
         throw new UnsupportedOperationException('database', $operation);
     }
 
+    /**
+     * Apply a direct or relational comparison to an Eloquent builder.
+     *
+     * @param Comparison $operation Comparison to translate.
+     * @param Builder $builder Eloquent builder receiving the comparison.
+     * @return Builder The updated Eloquent builder.
+     */
     private function applyComparison(Comparison $operation, Builder $builder): Builder
     {
         if (str_contains($operation->field(), '.')) {
@@ -83,6 +90,16 @@ class DatabaseDriver implements Driver
         return $this->applyOperator($operation, $builder);
     }
 
+    /**
+     * Apply a dotted field comparison through an Eloquent relationship path.
+     *
+     * The last path segment is treated as the related field and all preceding
+     * segments are passed to Eloquent as the relationship path.
+     *
+     * @param Comparison $operation Relational comparison to translate.
+     * @param Builder $builder Parent Eloquent builder.
+     * @return Builder The updated parent builder.
+     */
     private function applyRelationalComparison(Comparison $operation, Builder $builder): Builder
     {
         $segments = explode('.', $operation->field());
@@ -97,6 +114,16 @@ class DatabaseDriver implements Driver
         });
     }
 
+    /**
+     * Apply a logically grouped collection of operations.
+     *
+     * Nested groups are recursively translated while preserving their AND/OR
+     * boundaries inside Eloquent constraint closures.
+     *
+     * @param Group $group Logical group to translate.
+     * @param Builder $builder Eloquent builder receiving the group.
+     * @return Builder The updated Eloquent builder.
+     */
     private function applyGroup(Group $group, Builder $builder): Builder
     {
         if ($group->operations() === []) {
@@ -114,6 +141,13 @@ class DatabaseDriver implements Driver
         });
     }
 
+    /**
+     * Resolve and execute the operator strategy for a comparison.
+     *
+     * @param Comparison $operation Comparison containing the resolved operator.
+     * @param Builder $builder Eloquent builder receiving the operator.
+     * @return Builder The updated Eloquent builder.
+     */
     private function applyOperator(Comparison $operation, Builder $builder): Builder
     {
         $payload = new Payload(

--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Kettasoft\Filterable\Drivers;
+
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Exceptions\InvalidDriverDefinitionException;
+
+class DriverManager
+{
+    /**
+     * Runtime driver extensions keyed by alias.
+     *
+     * @var array<string, class-string<Driver>>
+     */
+    private static array $extensions = [];
+
+    /**
+     * Resolve a driver instance by name or class.
+     *
+     * @param Driver|string|null $driver
+     *
+     * @throws InvalidDriverDefinitionException
+     */
+    public static function resolve(Driver|string|null $driver = null): Driver
+    {
+        if ($driver instanceof Driver) {
+            return $driver;
+        }
+
+        $name = $driver ?? config('filterable.default_driver', 'database');
+        $definition = self::$extensions[$name]
+            ?? config("filterable.drivers.{$name}")
+            ?? (is_a($name, Driver::class, true) ? $name : null);
+
+        if (! is_string($definition) || ! is_a($definition, Driver::class, true)) {
+            throw new InvalidDriverDefinitionException($name, $definition);
+        }
+
+        $resolved = app($definition);
+
+        if (! $resolved instanceof Driver) {
+            throw new InvalidDriverDefinitionException($name, $resolved);
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * Register a new driver extension.
+     * 
+     * @param class-string<Driver> $driver
+     * 
+     * @throws InvalidDriverDefinitionException
+     */
+    public static function extend(string $name, string $driver): void
+    {
+        if (! is_a($driver, Driver::class, true)) {
+            throw new InvalidDriverDefinitionException($name, $driver);
+        }
+
+        self::$extensions[$name] = $driver;
+    }
+}

--- a/src/Drivers/DriverManager.php
+++ b/src/Drivers/DriverManager.php
@@ -15,11 +15,16 @@ class DriverManager
     private static array $extensions = [];
 
     /**
-     * Resolve a driver instance by name or class.
+     * Resolve a driver from an instance, configured alias, or class name.
      *
-     * @param Driver|string|null $driver
+     * Passing null resolves the configured default driver. Driver classes are
+     * instantiated through Laravel's service container.
      *
-     * @throws InvalidDriverDefinitionException
+     * @param Driver|class-string<Driver>|string|null $driver Driver instance,
+     *     configured alias, class name, or null for the default driver.
+     * @return Driver The resolved driver instance.
+     *
+     * @throws InvalidDriverDefinitionException When the definition does not implement Driver.
      */
     public static function resolve(Driver|string|null $driver = null): Driver
     {
@@ -46,11 +51,15 @@ class DriverManager
     }
 
     /**
-     * Register a new driver extension.
-     * 
-     * @param class-string<Driver> $driver
-     * 
-     * @throws InvalidDriverDefinitionException
+     * Register a driver class under a runtime alias.
+     *
+     * Runtime extensions take precedence over configured driver definitions.
+     *
+     * @param string $name Alias used to resolve the driver.
+     * @param class-string<Driver> $driver Driver implementation class.
+     * @return void
+     *
+     * @throws InvalidDriverDefinitionException When the class does not implement Driver.
      */
     public static function extend(string $name, string $driver): void
     {

--- a/src/Exceptions/InvalidDriverDefinitionException.php
+++ b/src/Exceptions/InvalidDriverDefinitionException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidDriverDefinitionException extends InvalidArgumentException
+{
+    public function __construct(string $driver, mixed $definition = null)
+    {
+        $description = is_string($definition)
+            ? $definition
+            : (is_object($definition) ? $definition::class : get_debug_type($definition));
+
+        parent::__construct("Filterable driver [{$driver}] has an invalid definition [{$description}].");
+    }
+}

--- a/src/Exceptions/InvalidDriverDefinitionException.php
+++ b/src/Exceptions/InvalidDriverDefinitionException.php
@@ -6,6 +6,12 @@ use InvalidArgumentException;
 
 class InvalidDriverDefinitionException extends InvalidArgumentException
 {
+    /**
+     * Create an exception for a driver definition that violates the contract.
+     *
+     * @param string $driver Alias or class name requested by the caller.
+     * @param mixed $definition Invalid configured or resolved definition.
+     */
     public function __construct(string $driver, mixed $definition = null)
     {
         $description = is_string($definition)

--- a/src/Exceptions/InvalidDriverTargetException.php
+++ b/src/Exceptions/InvalidDriverTargetException.php
@@ -6,6 +6,13 @@ use InvalidArgumentException;
 
 class InvalidDriverTargetException extends InvalidArgumentException
 {
+    /**
+     * Create an exception for a backend query unsupported by a driver.
+     *
+     * @param string $driver Driver that rejected the target.
+     * @param object $target Backend query object supplied to the driver.
+     * @param string $expected Expected target contract or class name.
+     */
     public function __construct(string $driver, object $target, string $expected)
     {
         $targetClass = $target::class;

--- a/src/Exceptions/InvalidDriverTargetException.php
+++ b/src/Exceptions/InvalidDriverTargetException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+use InvalidArgumentException;
+
+class InvalidDriverTargetException extends InvalidArgumentException
+{
+    public function __construct(string $driver, object $target, string $expected)
+    {
+        $targetClass = $target::class;
+
+        parent::__construct(
+            "Filterable driver [{$driver}] cannot operate on [{$targetClass}]; expected [{$expected}]."
+        );
+    }
+}

--- a/src/Exceptions/UnsupportedOperationException.php
+++ b/src/Exceptions/UnsupportedOperationException.php
@@ -7,6 +7,12 @@ use Kettasoft\Filterable\Operations\Contracts\Operation;
 
 class UnsupportedOperationException extends LogicException
 {
+    /**
+     * Create an exception for an operation a driver cannot translate.
+     *
+     * @param string $driver Driver that rejected the operation.
+     * @param Operation $operation Unsupported backend-independent instruction.
+     */
     public function __construct(string $driver, Operation $operation)
     {
         $operationClass = $operation::class;

--- a/src/Exceptions/UnsupportedOperationException.php
+++ b/src/Exceptions/UnsupportedOperationException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+use LogicException;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+
+class UnsupportedOperationException extends LogicException
+{
+    public function __construct(string $driver, Operation $operation)
+    {
+        $operationClass = $operation::class;
+
+        parent::__construct(
+            "Filterable driver [{$driver}] does not support operation [{$operationClass}]."
+        );
+    }
+}

--- a/src/Operations/Comparison.php
+++ b/src/Operations/Comparison.php
@@ -10,11 +10,11 @@ use Kettasoft\Filterable\Operations\Contracts\Operation;
 class Comparison implements Operation
 {
     /**
-     * Create a new Comparison instance.
-     * 
-     * @param string $field
-     * @param string $operator
-     * @param mixed $value
+     * Create a backend-independent field comparison.
+     *
+     * @param string $field Logical field or dotted relationship path.
+     * @param string $operator Canonical operator understood by a driver.
+     * @param mixed $value Final value to compare after input processing.
      */
     public function __construct(
         private string $field,
@@ -22,16 +22,31 @@ class Comparison implements Operation
         private mixed $value,
     ) {}
 
+    /**
+     * Get the logical field or relationship path being compared.
+     *
+     * @return string
+     */
     public function field(): string
     {
         return $this->field;
     }
 
+    /**
+     * Get the canonical comparison operator.
+     *
+     * @return string
+     */
     public function operator(): string
     {
         return $this->operator;
     }
 
+    /**
+     * Get the final comparison value.
+     *
+     * @return mixed
+     */
     public function value(): mixed
     {
         return $this->value;

--- a/src/Operations/Comparison.php
+++ b/src/Operations/Comparison.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Kettasoft\Filterable\Operations;
+
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+
+/**
+ * A backend-independent field comparison.
+ */
+class Comparison implements Operation
+{
+    /**
+     * Create a new Comparison instance.
+     * 
+     * @param string $field
+     * @param string $operator
+     * @param mixed $value
+     */
+    public function __construct(
+        private string $field,
+        private string $operator,
+        private mixed $value,
+    ) {}
+
+    public function field(): string
+    {
+        return $this->field;
+    }
+
+    public function operator(): string
+    {
+        return $this->operator;
+    }
+
+    public function value(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/Operations/Contracts/Operation.php
+++ b/src/Operations/Contracts/Operation.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Kettasoft\Filterable\Operations\Contracts;
+
+/**
+ * Represents a backend-independent filtering instruction.
+ */
+interface Operation
+{
+}

--- a/src/Operations/Group.php
+++ b/src/Operations/Group.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Kettasoft\Filterable\Operations;
+
+use InvalidArgumentException;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+
+/**
+ * A logical group of filtering operations.
+ */
+class Group implements Operation
+{
+    /**
+     * The boolean operator for the group.
+     * 
+     * @var list<Operation>
+     */
+    private array $operations;
+
+    /**
+     * Create a new operation group.
+     * 
+     * @param iterable<Operation> $operations
+     */
+    public function __construct(private string $boolean, iterable $operations)
+    {
+        $this->boolean = strtolower(trim($this->boolean));
+
+        if (! in_array($this->boolean, ['and', 'or'], true)) {
+            throw new InvalidArgumentException('An operation group boolean must be [and] or [or].');
+        }
+
+        $this->operations = [];
+
+        foreach ($operations as $operation) {
+            if (! $operation instanceof Operation) {
+                throw new InvalidArgumentException('Every group member must implement the Operation contract.');
+            }
+
+            $this->operations[] = $operation;
+        }
+    }
+
+    public function boolean(): string
+    {
+        return $this->boolean;
+    }
+
+    /**
+     * @return list<Operation>
+     */
+    public function operations(): array
+    {
+        return $this->operations;
+    }
+}

--- a/src/Operations/Group.php
+++ b/src/Operations/Group.php
@@ -11,16 +11,19 @@ use Kettasoft\Filterable\Operations\Contracts\Operation;
 class Group implements Operation
 {
     /**
-     * The boolean operator for the group.
-     * 
+     * Operations contained by the group.
+     *
      * @var list<Operation>
      */
     private array $operations;
 
     /**
-     * Create a new operation group.
-     * 
-     * @param iterable<Operation> $operations
+     * Create a logical group of backend-independent operations.
+     *
+     * @param string $boolean Boolean used to join members; accepts `and` or `or`.
+     * @param iterable<Operation> $operations Operations contained by the group.
+     *
+     * @throws InvalidArgumentException When the boolean or a group member is invalid.
      */
     public function __construct(private string $boolean, iterable $operations)
     {
@@ -41,13 +44,20 @@ class Group implements Operation
         }
     }
 
+    /**
+     * Get the normalized boolean used to join the group members.
+     *
+     * @return string Either `and` or `or`.
+     */
     public function boolean(): string
     {
         return $this->boolean;
     }
 
     /**
-     * @return list<Operation>
+     * Get the operations contained by this group in their original order.
+     *
+     * @return list<Operation> Ordered group members.
      */
     public function operations(): array
     {

--- a/tests/Unit/Drivers/DatabaseDriverTest.php
+++ b/tests/Unit/Drivers/DatabaseDriverTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Drivers;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Kettasoft\Filterable\Drivers\DatabaseDriver;
+use Kettasoft\Filterable\Engines\Foundation\Operators\Contracts\Operator;
+use Kettasoft\Filterable\Engines\Foundation\Operators\OperatorResolver;
+use Kettasoft\Filterable\Exceptions\InvalidDriverTargetException;
+use Kettasoft\Filterable\Exceptions\UnsupportedOperationException;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Operations\Group;
+use Kettasoft\Filterable\Support\Payload;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\Models\Tag;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class DatabaseDriverTest extends TestCase
+{
+
+    private function driver(): DatabaseDriver
+    {
+        return new DatabaseDriver();
+    }
+
+    public function test_it_applies_a_comparison_operation(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Comparison('views', '>=', 20), Post::query());
+
+        $this->assertSame([20, 30], $query->pluck('views')->sort()->values()->all());
+    }
+
+    public function test_it_applies_special_operator_strategies(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Comparison('views', 'in', [10, 30]), Post::query());
+
+        $this->assertSame([10, 30], $query->pluck('views')->sort()->values()->all());
+    }
+
+    public function test_it_applies_relational_comparisons(): void
+    {
+        [$first, $second] = $this->seedPosts();
+        Tag::factory()->create(['post_id' => $first->id, 'name' => 'featured']);
+        Tag::factory()->create(['post_id' => $second->id, 'name' => 'archived']);
+
+        $query = $this->driver()->apply(
+            new Comparison('tags.name', '=', 'featured'),
+            Post::query()
+        );
+
+        $this->assertSame([$first->id], $query->pluck('id')->all());
+    }
+
+    public function test_it_applies_and_groups(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Group('and', [
+            new Comparison('status', '=', 'pending'),
+            new Comparison('views', '>=', 20),
+        ]), Post::query());
+
+        $this->assertSame([20], $query->pluck('views')->all());
+    }
+
+    public function test_it_applies_or_groups(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Group('or', [
+            new Comparison('status', '=', 'active'),
+            new Comparison('views', '>=', 30),
+        ]), Post::query());
+
+        $this->assertSame([10, 30], $query->pluck('views')->sort()->values()->all());
+    }
+
+    public function test_it_applies_nested_groups(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Group('and', [
+            new Group('or', [
+                new Comparison('status', '=', 'active'),
+                new Comparison('status', '=', 'pending'),
+            ]),
+            new Comparison('views', '>=', 20),
+        ]), Post::query());
+
+        $this->assertSame([20], $query->pluck('views')->all());
+    }
+
+    public function test_an_empty_group_does_not_change_the_query(): void
+    {
+        $this->seedPosts();
+
+        $query = $this->driver()->apply(new Group('and', []), Post::query());
+
+        $this->assertCount(3, $query->get());
+    }
+
+    public function test_it_uses_injected_operator_strategies(): void
+    {
+        $this->seedPosts();
+        $driver = new DatabaseDriver(new OperatorResolver([
+            'starts with' => StartsWithOperator::class,
+        ]));
+
+        $query = $driver->apply(new Comparison('title', 'starts with', 'Sec'), Post::query());
+
+        $this->assertSame(['Second'], $query->pluck('title')->all());
+    }
+
+    public function test_it_rejects_a_non_eloquent_target(): void
+    {
+        $this->expectException(InvalidDriverTargetException::class);
+
+        $this->driver()->apply(new Comparison('views', '>=', 20), new \stdClass());
+    }
+
+    public function test_it_rejects_an_unsupported_operation(): void
+    {
+        $this->expectException(UnsupportedOperationException::class);
+
+        $operation = new class implements Operation {};
+
+        $this->driver()->apply($operation, Post::query());
+    }
+
+    private function seedPosts(): array
+    {
+        return [
+            Post::factory()->create(['title' => 'First', 'status' => 'active', 'views' => 10]),
+            Post::factory()->create(['title' => 'Second', 'status' => 'pending', 'views' => 20]),
+            Post::factory()->create(['title' => 'Third', 'status' => 'stopped', 'views' => 30]),
+        ];
+    }
+}
+
+class StartsWithOperator implements Operator
+{
+    public function apply(Builder $builder, Payload $payload): Builder
+    {
+        return $builder->where($payload->field, 'like', $payload->value . '%');
+    }
+}

--- a/tests/Unit/Drivers/DriverManagerTest.php
+++ b/tests/Unit/Drivers/DriverManagerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Drivers;
+
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Drivers\DatabaseDriver;
+use Kettasoft\Filterable\Drivers\DriverManager;
+use Kettasoft\Filterable\Exceptions\InvalidDriverDefinitionException;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Tests\TestCase;
+
+class DriverManagerTest extends TestCase
+{
+    public function test_it_resolves_the_default_database_driver(): void
+    {
+        $this->assertInstanceOf(DatabaseDriver::class, DriverManager::resolve());
+    }
+
+    public function test_it_resolves_a_configured_driver_alias(): void
+    {
+        config()->set('filterable.drivers.testing', FakeDriver::class);
+
+        $this->assertInstanceOf(FakeDriver::class, DriverManager::resolve('testing'));
+    }
+
+    public function test_it_resolves_a_driver_class_or_instance(): void
+    {
+        $instance = new FakeDriver();
+
+        $this->assertInstanceOf(FakeDriver::class, DriverManager::resolve(FakeDriver::class));
+        $this->assertSame($instance, DriverManager::resolve($instance));
+    }
+
+    public function test_it_can_register_a_runtime_driver_extension(): void
+    {
+        DriverManager::extend('runtime-testing', FakeDriver::class);
+
+        $this->assertInstanceOf(FakeDriver::class, DriverManager::resolve('runtime-testing'));
+    }
+
+    public function test_it_rejects_an_invalid_driver_definition(): void
+    {
+        config()->set('filterable.drivers.invalid', \stdClass::class);
+
+        $this->expectException(InvalidDriverDefinitionException::class);
+
+        DriverManager::resolve('invalid');
+    }
+}
+
+class FakeDriver implements Driver
+{
+    public function apply(Operation $operation, object $query): object
+    {
+        return $query;
+    }
+}

--- a/tests/Unit/Operations/OperationTest.php
+++ b/tests/Unit/Operations/OperationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Operations;
+
+use InvalidArgumentException;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Group;
+use PHPUnit\Framework\TestCase;
+
+class OperationTest extends TestCase
+{
+    public function test_comparison_exposes_backend_independent_parts(): void
+    {
+        $operation = new Comparison('views', '>=', 100);
+
+        $this->assertSame('views', $operation->field());
+        $this->assertSame('>=', $operation->operator());
+        $this->assertSame(100, $operation->value());
+    }
+
+    public function test_group_normalizes_its_boolean_and_preserves_operations(): void
+    {
+        $comparison = new Comparison('status', '=', 'active');
+        $group = new Group(' OR ', [$comparison]);
+
+        $this->assertSame('or', $group->boolean());
+        $this->assertSame([$comparison], $group->operations());
+    }
+
+    public function test_group_rejects_an_unknown_boolean(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Group('xor', []);
+    }
+
+    public function test_group_rejects_non_operation_members(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Group('and', ['not-an-operation']);
+    }
+}


### PR DESCRIPTION
## Overview

This PR introduces the initial Driver abstraction for Filterable.

The goal is to separate **what should be filtered** from **how the filtering is executed**, preparing the package for non-Eloquent backends such as Meilisearch while preserving the existing v3 behavior.

This is a foundational PR only. The current Filterable execution lifecycle is not switched to Drivers yet, preventing behavioral or public API changes.

## What Changed

### Backend-neutral Operations

Added a minimal operation model that describes filtering without depending on Eloquent:

- `Operation` contract
- `Comparison` operation
- Logical `Group` operation
- Nested `AND` and `OR` group support
- Validation for invalid group booleans and members

Example:

```php
new Comparison(
    field: 'views',
    operator: '>=',
    value: 100,
);
```

Grouped operations can be expressed as:

```php
new Group('and', [
    new Comparison('status', '=', 'published'),
    new Comparison('views', '>=', 100),
]);
```

### Driver Contract

Added a minimal backend-independent `Driver` contract:

```php
public function apply(
    Operation $operation,
    object $query,
): object;
```

Each Driver is responsible for:

- Validating its backend query target
- Translating supported Operations
- Returning the updated or replaced query object
- Rejecting unsupported Operations explicitly

### Driver Manager

Added `DriverManager` with support for resolving Drivers through:

- The configured default Driver
- A configured Driver alias
- A Driver class name
- An existing Driver instance
- Runtime extensions registered using `DriverManager::extend()`

Driver implementations are resolved through Laravel's service container.

### Database Driver

Added the initial `DatabaseDriver` implementation for Eloquent.

It currently supports:

- Direct field comparisons
- Dotted relational fields
- Deep relationship paths
- Logical `AND` groups
- Logical `OR` groups
- Recursively nested groups
- Existing built-in operator strategies
- Custom injected operator strategies
- Empty groups without modifying the query

The Driver reuses the existing operator pipeline to preserve current database filtering semantics.

### Configuration

Added the initial Driver configuration:

```php
'default_driver' => 'database',

'drivers' => [
    'database' => DatabaseDriver::class,
],
```

The configuration is introduced in this PR for Driver resolution. Integration with the main `Filterable` lifecycle will follow in a separate PR.

### Exceptions

Added explicit exceptions for:

- Invalid Driver definitions
- Unsupported backend query targets
- Operations unsupported by a Driver

## Backward Compatibility

This PR is fully additive:

- Existing engines are unchanged.
- `Filterable::apply()` is unchanged.
- `Payload` behavior is unchanged.
- `PayloadApplier` remains active.
- Eloquent remains the package's current execution backend.
- No existing public API is removed or modified.

## Testing

Added focused tests covering:

- Comparison Operations
- Logical groups and validation
- Default and custom Driver resolution
- Runtime Driver registration
- Database comparisons
- Special and custom operators
- Relational filtering
- AND/OR groups
- Nested groups
- Invalid query targets
- Unsupported Operations

Full test suite:

```text
516 tests
902 assertions
All passing
```

## Next Step

The next PR will connect this foundation to the Filterable lifecycle:

- Resolve the configured Driver during execution
- Add `useDriver()` and `getDriver()`
- Route structured engines through Operations and Drivers
- Preserve the existing Invokable/Eloquent behavior
- Keep the v3 public API backward compatible