### PR TITLE
Integrate drivers with the Filterable execution lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - Backend-independent comparison and logical-group operations.
 - A driver contract and manager with an initial Eloquent database driver.
+- Per-filter Driver selection through `useDriver()` and `getDriver()`.
+
+### Changed
+
+- Ruleset, Expression, and Tree comparisons are dispatched through the selected
+  Driver while preserving the existing Eloquent lifecycle.
+- Driver infrastructure failures are surfaced in strict and permissive modes
+  instead of being silently skipped.
 
 ## [3.0.0] - 2026-09-10
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -259,6 +259,10 @@ export default defineUserConfig({
                             text: "Operator Strategies",
                             link: "/features/operators",
                         },
+                        {
+                            text: "Filter Drivers",
+                            link: "/features/drivers",
+                        },
                     ],
                 },
                 {

--- a/docs/features/drivers.md
+++ b/docs/features/drivers.md
@@ -1,0 +1,119 @@
+---
+title: Filter Drivers
+description: Select how Filterable operations are translated for the active query backend.
+tags: [drivers, operations, database, architecture]
+---
+
+# Filter Drivers
+
+A Driver decides how an approved filter operation is applied to a query backend. Engines remain responsible for understanding the request shape, validating fields and operators, and producing sanitized payloads.
+
+```text
+Request data
+    ↓
+Engine → validation and sanitization
+    ↓
+Comparison operation
+    ↓
+Driver
+    ↓
+Backend query
+```
+
+Filterable uses the Eloquent database Driver by default, so existing applications do not need to change their configuration or filtering calls.
+
+## Select a Driver
+
+The default Driver is configured in `config/filterable.php`:
+
+```php
+'default_driver' => 'database',
+
+'drivers' => [
+    'database' => \Kettasoft\Filterable\Drivers\DatabaseDriver::class,
+],
+```
+
+Override it for one Filterable instance with `useDriver()`:
+
+```php
+$filterable = Filterable::for(Post::class, $request)
+    ->using('ruleset')
+    ->useDriver('database');
+```
+
+Use `getDriver()` when you need to inspect the resolved implementation:
+
+```php
+$driver = $filterable->getDriver();
+```
+
+Aliases and Driver classes are resolved through Laravel's service container, so constructor dependencies can be injected.
+
+## Operations and Payloads
+
+`Payload` and `Operation` have different responsibilities:
+
+- A `Payload` preserves request lifecycle information, including the raw and sanitized values.
+- An `Operation` describes the final backend-independent comparison that should be executed.
+- The selected Driver translates that Operation into backend-specific query calls.
+
+Ruleset, Expression, and Tree dispatch their resolved comparisons through the selected Driver. Applied and skipped state continues to store `Payload` snapshots, so existing diagnostics remain unchanged.
+
+## Database Driver
+
+The built-in database Driver translates comparisons into Eloquent constraints. It supports:
+
+- Direct field comparisons
+- Dotted and deeply nested relationship fields
+- Built-in and custom operator strategies
+- Logical and recursively nested Operation groups
+
+Existing calls continue to work without explicitly selecting the Driver:
+
+```php
+$posts = Filterable::for(Post::class, $request)
+    ->using('expression')
+    ->setAllowedFields(['status', 'views'])
+    ->get();
+```
+
+## Custom Drivers in the Current Lifecycle
+
+A custom Driver implements the `Driver` contract and can be registered under an alias:
+
+```php
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Drivers\DatabaseDriver;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+
+final class CustomDatabaseDriver implements Driver
+{
+    public function __construct(
+        private DatabaseDriver $database,
+    ) {}
+
+    public function apply(Operation $operation, object $query): object
+    {
+        // Add application-specific behavior before or after delegation.
+        return $this->database->apply($operation, $query);
+    }
+}
+```
+
+```php
+'drivers' => [
+    'database' => \Kettasoft\Filterable\Drivers\DatabaseDriver::class,
+    'custom' => App\Filtering\CustomDatabaseDriver::class,
+],
+```
+
+The current v3 execution lifecycle still starts from an Eloquent Builder. A Driver selected through `Filterable::useDriver()` must therefore return an Eloquent Builder. Returning an incompatible object fails explicitly instead of silently leaving the query unfiltered.
+
+::: warning Invokable filters
+Invokable filter methods can contain arbitrary Eloquent domain logic. They keep their existing behavior and are not translated into Operations yet. Portable Invokable Operations and external backend targets will be introduced separately.
+:::
+
+## Driver Failures
+
+Invalid Driver definitions, unsupported targets, unsupported Operations, and incompatible results are infrastructure errors. Filterable always surfaces these errors, including in permissive filtering mode, because silently skipping them could return unfiltered data.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -15,7 +15,9 @@ Authorization → Request validation
         ↓
 Selected engine → Payload sanitization
         ↓
-Eloquent query → Sorting → Result
+Operation → Selected driver
+        ↓
+Backend query → Sorting → Result
 ```
 
 ## Two ways to start a filter
@@ -65,7 +67,7 @@ protected function status(Payload $payload): Builder
 }
 ```
 
-Ruleset, Expression, and Tree apply their payloads automatically.
+Ruleset, Expression, and Tree turn their resolved payloads into comparison operations and dispatch them through the selected [Driver](/features/drivers). Invokable methods keep direct control of their domain-specific Eloquent logic.
 
 ## Safe filtering
 

--- a/src/Engines/Expression.php
+++ b/src/Engines/Expression.php
@@ -8,9 +8,7 @@ use Kettasoft\Filterable\Support\RelationFieldParser;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
 use Kettasoft\Filterable\Support\ConditionNormalizer;
 use Kettasoft\Filterable\Support\ValidateTableColumns;
-use Kettasoft\Filterable\Engines\Foundation\PayloadApplier;
 use Kettasoft\Filterable\Engines\Foundation\PayloadFactory;
-use Kettasoft\Filterable\Engines\Foundation\Appliers\Applier;
 use Kettasoft\Filterable\Engines\Foundation\Parsers\Dissector;
 
 class Expression extends Engine
@@ -35,7 +33,7 @@ class Expression extends Engine
     );
 
     foreach ($filters as $field => $condition) {
-      $this->attempt(function () use ($builder, $field, $condition) {
+      $this->attempt(function () use (&$builder, $field, $condition) {
 
         // Normalize the condition to [ operator => value ].
         $condition = ConditionNormalizer::normalize($condition, $this->defaultOperator());
@@ -46,7 +44,7 @@ class Expression extends Engine
           new Payload($field, $dissector->operator, $this->sanitizeValue($field, $dissector->value), $dissector->value)
         );
 
-        Applier::apply(new PayloadApplier($payload), $builder);
+        $builder = $this->dispatchPayload($payload, $builder);
         return $this->commit($field, $payload);
       });
     }

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -13,6 +13,9 @@ use Kettasoft\Filterable\Engines\Exceptions\SkipExecution;
 use Kettasoft\Filterable\Engines\Contracts\HasAllowedFieldChecker;
 use Kettasoft\Filterable\Engines\Contracts\HasInteractsWithOperators;
 use Kettasoft\Filterable\Support\Payload;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
+use Kettasoft\Filterable\Exceptions\InvalidDriverResultException;
 
 abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Strictable, Executable, HasAllowedFieldChecker, Skippable
 {
@@ -45,6 +48,8 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
   {
     try {
       return $callback->call($this);
+    } catch (DriverException $e) {
+      throw $e;
     } catch (\Throwable $e) {
       return $this->context->getExceptionHandler()->handle($e, $this);
     }
@@ -169,6 +174,34 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
   public function getResources(): Resources
   {
     return $this->context->getResources();
+  }
+
+  /**
+   * Translate an approved payload into an operation and dispatch it to the driver.
+   *
+   * The current v3 execution lifecycle remains Eloquent-based, so drivers used
+   * through Filterable must return an Eloquent builder until the generic
+   * backend lifecycle is introduced.
+   *
+   * @param Payload $payload Validated and resolved filter payload.
+   * @param Builder $builder Eloquent builder receiving the operation.
+   * @return Builder The builder returned by the active driver.
+   *
+   * @throws InvalidDriverResultException When the driver returns a non-Eloquent result.
+   */
+  final protected function dispatchPayload(Payload $payload, Builder $builder): Builder
+  {
+    $driver = $this->context->getDriver();
+    $result = $driver->apply(
+      new Comparison($payload->field, $payload->operator, $payload->value),
+      $builder
+    );
+
+    if (! $result instanceof Builder) {
+      throw new InvalidDriverResultException($driver::class, $result, Builder::class);
+    }
+
+    return $result;
   }
 
   /**

--- a/src/Engines/Ruleset.php
+++ b/src/Engines/Ruleset.php
@@ -7,9 +7,7 @@ use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Support\RelationFieldParser;
 use Kettasoft\Filterable\Traits\FieldNormalizer;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
-use Kettasoft\Filterable\Engines\Foundation\PayloadApplier;
 use Kettasoft\Filterable\Engines\Foundation\PayloadFactory;
-use Kettasoft\Filterable\Engines\Foundation\Appliers\Applier;
 use Kettasoft\Filterable\Engines\Foundation\Parsers\Dissector;
 
 class Ruleset extends Engine
@@ -36,14 +34,14 @@ class Ruleset extends Engine
     );
 
     foreach ($data as $field => $dissector) {
-      $this->attempt(function () use ($builder, $dissector, $field): bool {
+      $this->attempt(function () use (&$builder, $dissector, $field): bool {
         $dissector = Dissector::parse($dissector, $this->defaultOperator());
 
         $payload = (new PayloadFactory($this))->make(
           new Payload($field, $dissector->operator, $this->sanitizeValue($field, $dissector->value), $dissector->value)
         );
 
-        Applier::apply(new PayloadApplier($payload), $builder);
+        $builder = $this->dispatchPayload($payload, $builder);
 
         return $this->commit($field, $payload);
       });

--- a/src/Engines/Tree.php
+++ b/src/Engines/Tree.php
@@ -7,9 +7,7 @@ use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Support\TreeNode;
 use Kettasoft\Filterable\Traits\FieldNormalizer;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
-use Kettasoft\Filterable\Engines\Foundation\PayloadApplier;
 use Kettasoft\Filterable\Engines\Foundation\PayloadFactory;
-use Kettasoft\Filterable\Engines\Foundation\Appliers\Applier;
 
 class Tree extends Engine
 {
@@ -59,7 +57,7 @@ class Tree extends Engine
         new Payload($node->field, $node->operator ?? $this->defaultOperator(), $this->sanitizeValue($node->field, $node->value), $node->value)
       );
 
-      Applier::apply(new PayloadApplier($payload), $builder);
+      $builder = $this->dispatchPayload($payload, $builder);
 
       $this->commit($node->field, $payload);
     }

--- a/src/Exceptions/Contracts/DriverException.php
+++ b/src/Exceptions/Contracts/DriverException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions\Contracts;
+
+use Throwable;
+
+/**
+ * Marks driver infrastructure errors that must never be silently skipped.
+ */
+interface DriverException extends Throwable
+{
+}

--- a/src/Exceptions/InvalidDriverDefinitionException.php
+++ b/src/Exceptions/InvalidDriverDefinitionException.php
@@ -3,8 +3,9 @@
 namespace Kettasoft\Filterable\Exceptions;
 
 use InvalidArgumentException;
+use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
 
-class InvalidDriverDefinitionException extends InvalidArgumentException
+class InvalidDriverDefinitionException extends InvalidArgumentException implements DriverException
 {
     /**
      * Create an exception for a driver definition that violates the contract.

--- a/src/Exceptions/InvalidDriverResultException.php
+++ b/src/Exceptions/InvalidDriverResultException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kettasoft\Filterable\Exceptions;
+
+use UnexpectedValueException;
+use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
+
+class InvalidDriverResultException extends UnexpectedValueException implements DriverException
+{
+  /**
+   * Create an exception for a driver result incompatible with the active lifecycle.
+   *
+   * @param string $driver Driver implementation that returned the result.
+   * @param object $result Backend query object returned by the driver.
+   * @param string $expected Expected result contract or class name.
+   */
+  public function __construct(string $driver, object $result, string $expected)
+  {
+    $resultClass = $result::class;
+
+    parent::__construct(
+      "Filterable driver [{$driver}] returned [{$resultClass}]; expected [{$expected}]."
+    );
+  }
+}

--- a/src/Exceptions/InvalidDriverTargetException.php
+++ b/src/Exceptions/InvalidDriverTargetException.php
@@ -3,8 +3,9 @@
 namespace Kettasoft\Filterable\Exceptions;
 
 use InvalidArgumentException;
+use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
 
-class InvalidDriverTargetException extends InvalidArgumentException
+class InvalidDriverTargetException extends InvalidArgumentException implements DriverException
 {
     /**
      * Create an exception for a backend query unsupported by a driver.

--- a/src/Exceptions/UnsupportedOperationException.php
+++ b/src/Exceptions/UnsupportedOperationException.php
@@ -3,9 +3,10 @@
 namespace Kettasoft\Filterable\Exceptions;
 
 use LogicException;
+use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
 use Kettasoft\Filterable\Operations\Contracts\Operation;
 
-class UnsupportedOperationException extends LogicException
+class UnsupportedOperationException extends LogicException implements DriverException
 {
     /**
      * Create an exception for an operation a driver cannot translate.

--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -16,6 +16,8 @@ use Kettasoft\Filterable\Contracts\Authorizable;
 use Kettasoft\Filterable\Sanitization\Sanitizer;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Support\Payload;
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Drivers\DriverManager;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
 use Kettasoft\Filterable\Foundation\Sorting\Sorter;
 use Kettasoft\Filterable\Contracts\FilterableContext;
@@ -54,6 +56,13 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
    * @var Engine
    */
   protected Engine $engine;
+
+  /**
+   * The backend driver used to translate filter operations.
+   *
+   * @var Driver
+   */
+  protected Driver $driver;
 
   /**
    * Resources instance.
@@ -209,6 +218,7 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   {
     $this->sanitizer = new Sanitizer($this->sanitizers);
     $this->resources = new Resources($this->settings());
+    $this->resolveDriver();
     $this->resolveEngine();
     $this->parseIncomingRequestData();
   }
@@ -748,6 +758,30 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   }
 
   /**
+   * Override the backend driver for this Filterable instance.
+   *
+   * @param Driver|class-string<Driver>|string $driver Driver instance,
+   *     configured alias, or implementation class.
+   * @return static
+   */
+  public function useDriver(Driver|string $driver): static
+  {
+    $this->driver = DriverManager::resolve($driver);
+
+    return $this;
+  }
+
+  /**
+   * Get the backend driver selected for this Filterable instance.
+   *
+   * @return Driver
+   */
+  public function getDriver(): Driver
+  {
+    return $this->driver;
+  }
+
+  /**
    * Get the current request instance.
    * @return Request
    */
@@ -862,6 +896,16 @@ class Filterable implements FilterableContext, Authorizable, Validatable, Commit
   private function resolveEngine()
   {
     $this->useEngine((new HeaderDrivenEngineSelector($this->request))->resolve());
+  }
+
+  /**
+   * Resolve the configured default backend driver.
+   *
+   * @return void
+   */
+  private function resolveDriver(): void
+  {
+    $this->driver = DriverManager::resolve();
   }
 
   /**

--- a/src/Providers/FilterableServiceProvider.php
+++ b/src/Providers/FilterableServiceProvider.php
@@ -14,6 +14,7 @@ use Kettasoft\Filterable\Commands\InspectFilterCommand;
 use Kettasoft\Filterable\Commands\SetupFilterableCommand;
 use Kettasoft\Filterable\Commands\FilterableDiscoverCommand;
 use Kettasoft\Filterable\Foundation\Events\FilterableEventManager;
+use Kettasoft\Filterable\Engines\Foundation\Operators\OperatorResolver;
 use Kettasoft\Filterable\Foundation\Caching\FilterableCacheManager;
 use Kettasoft\Filterable\Foundation\Caching\CacheInvalidationObserver;
 use Kettasoft\Filterable\Foundation\Profiler\Storage\FileProfilerStorage;
@@ -98,6 +99,7 @@ class FilterableServiceProvider extends ServiceProvider
     {
         $this->mergeConfiguration();
         $this->registerCoreBindings();
+        $this->registerDriverBindings();
         $this->registerEventManager();
         $this->registerCacheManager();
         $this->registerProfilerStorage();
@@ -168,6 +170,21 @@ class FilterableServiceProvider extends ServiceProvider
         if (!class_exists('Filterable')) {
             class_alias(\Kettasoft\Filterable\Facades\Filterable::class, 'Filterable');
         }
+    }
+
+    /**
+     * Register dependencies used by backend Drivers.
+     *
+     * The resolver is intentionally transient so runtime configuration changes
+     * and per-test operator strategies are reflected by each resolved Driver.
+     *
+     * @return void
+     */
+    protected function registerDriverBindings(): void
+    {
+        $this->app->bind(OperatorResolver::class, function (): OperatorResolver {
+            return OperatorResolver::fromConfig();
+        });
     }
 
     /**

--- a/tests/Unit/Drivers/DatabaseDriverTest.php
+++ b/tests/Unit/Drivers/DatabaseDriverTest.php
@@ -116,6 +116,17 @@ class DatabaseDriverTest extends TestCase
         $this->assertSame(['Second'], $query->pluck('title')->all());
     }
 
+    public function test_a_container_resolved_driver_uses_configured_operator_strategies(): void
+    {
+        $this->seedPosts();
+        config()->set('filterable.operator_strategies.starts_with', StartsWithOperator::class);
+
+        $driver = app(DatabaseDriver::class);
+        $query = $driver->apply(new Comparison('title', 'starts_with', 'Sec'), Post::query());
+
+        $this->assertSame(['Second'], $query->pluck('title')->all());
+    }
+
     public function test_it_rejects_a_non_eloquent_target(): void
     {
         $this->expectException(InvalidDriverTargetException::class);

--- a/tests/Unit/Drivers/DriverLifecycleTest.php
+++ b/tests/Unit/Drivers/DriverLifecycleTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Kettasoft\Filterable\Tests\Unit\Drivers;
+
+use Illuminate\Contracts\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Kettasoft\Filterable\Drivers\Contracts\Driver;
+use Kettasoft\Filterable\Drivers\DatabaseDriver;
+use Kettasoft\Filterable\Exceptions\InvalidDriverResultException;
+use Kettasoft\Filterable\Filterable;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Support\Payload;
+use Kettasoft\Filterable\Tests\Models\Post;
+use Kettasoft\Filterable\Tests\TestCase;
+use Symfony\Component\HttpFoundation\InputBag;
+
+class DriverLifecycleTest extends TestCase
+{
+  public function test_filterable_resolves_the_configured_default_driver(): void
+  {
+    config()->set('filterable.default_driver', 'recording');
+    config()->set('filterable.drivers.recording', RecordingDriver::class);
+
+    $filterable = Filterable::for(Post::class);
+
+    $this->assertInstanceOf(RecordingDriver::class, $filterable->getDriver());
+  }
+
+  public function test_filterable_can_override_the_driver_for_one_instance(): void
+  {
+    $driver = new RecordingDriver();
+    $filterable = Filterable::for(Post::class);
+
+    $result = $filterable->useDriver($driver);
+
+    $this->assertSame($filterable, $result);
+    $this->assertSame($driver, $filterable->getDriver());
+  }
+
+  public function test_ruleset_dispatches_a_resolved_comparison_to_the_driver(): void
+  {
+    $this->seedPosts();
+    $driver = new RecordingDriver();
+    $request = Request::create('/posts', 'GET', [
+      'state' => ['eq' => ' ACTIVE '],
+    ]);
+
+    $filterable = Filterable::for(Post::class, $request)
+      ->using('ruleset')
+      ->setAllowedFields(['state'])
+      ->setFieldsMap(['state' => 'status'])
+      ->setSanitizers(['state' => fn($value) => strtolower(trim($value))])
+      ->useDriver($driver);
+
+    $results = $filterable->get();
+
+    $this->assertCount(1, $results);
+    $this->assertComparison($driver->operations[0], 'status', '=', 'active');
+    $this->assertSame(' ACTIVE ', $filterable->applied('state')->rawValue);
+  }
+
+  public function test_expression_dispatches_comparisons_to_the_driver(): void
+  {
+    $this->seedPosts();
+    $driver = new RecordingDriver();
+    $request = Request::create('/posts', 'GET', [
+      'filter' => ['views' => ['gte' => 20]],
+    ]);
+
+    $results = Filterable::for(Post::class, $request)
+      ->using('expression')
+      ->setAllowedFields(['views'])
+      ->useDriver($driver)
+      ->get();
+
+    $this->assertSame([20, 30], $results->pluck('views')->sort()->values()->all());
+    $this->assertComparison($driver->operations[0], 'views', '>=', 20);
+  }
+
+  public function test_tree_dispatches_each_leaf_comparison_to_the_driver(): void
+  {
+    $this->seedPosts();
+    $driver = new RecordingDriver();
+    $request = Request::create('/posts');
+    $request->setJson(new InputBag([
+      'filter' => [
+        'and' => [
+          ['field' => 'status', 'operator' => 'eq', 'value' => 'active'],
+          ['or' => [
+            ['field' => 'views', 'operator' => 'gte', 'value' => 30],
+          ]],
+        ],
+      ],
+    ]));
+
+    Filterable::for(Post::class, $request)
+      ->using('tree')
+      ->setAllowedFields(['status', 'views'])
+      ->useDriver($driver)
+      ->get();
+
+    $this->assertCount(2, $driver->operations);
+    $this->assertComparison($driver->operations[0], 'status', '=', 'active');
+    $this->assertComparison($driver->operations[1], 'views', '>=', 30);
+  }
+
+  public function test_invokable_domain_methods_keep_their_existing_database_behavior(): void
+  {
+    $this->seedPosts();
+    $driver = new RecordingDriver();
+    $request = Request::create('/posts', 'GET', ['status' => 'active']);
+    $filter = new class($request) extends Filterable {
+      protected $filters = ['status'];
+
+      protected function status(Payload $payload): Builder
+      {
+        return $this->getBuilder()->where($payload->field, $payload->value);
+      }
+    };
+
+    $results = $filter
+      ->setModel(Post::class)
+      ->setBuilder(Post::query())
+      ->useDriver($driver)
+      ->get();
+
+    $this->assertCount(1, $results);
+    $this->assertSame([], $driver->operations);
+  }
+
+  public function test_the_eloquent_lifecycle_rejects_a_non_eloquent_driver_result(): void
+  {
+    $this->seedPosts();
+    $request = Request::create('/posts', 'GET', [
+      'views' => ['gte' => 20],
+    ]);
+
+    $this->expectException(InvalidDriverResultException::class);
+
+    Filterable::for(Post::class, $request)
+      ->using('ruleset')
+      ->strict()
+      ->setAllowedFields(['views'])
+      ->useDriver(new InvalidResultDriver())
+      ->get();
+  }
+
+  private function assertComparison(
+    Operation $operation,
+    string $field,
+    string $operator,
+    mixed $value
+  ): void {
+    $this->assertInstanceOf(Comparison::class, $operation);
+    $this->assertSame($field, $operation->field());
+    $this->assertSame($operator, $operation->operator());
+    $this->assertSame($value, $operation->value());
+  }
+
+  private function seedPosts(): void
+  {
+    Post::factory()->create(['status' => 'active', 'views' => 10]);
+    Post::factory()->create(['status' => 'pending', 'views' => 20]);
+    Post::factory()->create(['status' => 'stopped', 'views' => 30]);
+  }
+}
+
+class RecordingDriver implements Driver
+{
+  /**
+   * @var list<Operation>
+   */
+  public array $operations = [];
+
+  public function apply(Operation $operation, object $query): object
+  {
+    $this->operations[] = $operation;
+
+    return (new DatabaseDriver())->apply($operation, $query);
+  }
+}
+
+class InvalidResultDriver implements Driver
+{
+  public function apply(Operation $operation, object $query): object
+  {
+    return new \stdClass();
+  }
+}


### PR DESCRIPTION
## Overview

This PR connects the Driver foundation to Filterable's active execution lifecycle while preserving the existing v3 Eloquent API and behavior.

Ruleset, Expression, and Tree comparisons are now represented as backend-independent `Comparison` operations and dispatched through the selected Driver. The existing `DatabaseDriver` remains the default implementation.

## What Changed

### Driver Resolution

Filterable now resolves the configured default Driver during initialization:

```php
'default_driver' => 'database',
```

The resolved Driver is stored on each Filterable instance and is available through:

```php
$filterable->getDriver();
```

### Per-instance Driver Selection

Added `useDriver()` for overriding the configured Driver on a specific Filterable instance:

```php
$filterable = Filterable::for(Post::class, $request)
    ->using('ruleset')
    ->useDriver('database');
```

`useDriver()` accepts:

- A configured Driver alias
- A Driver implementation class
- An existing Driver instance

Driver classes continue to be resolved through Laravel's service container.

### Structured Engine Integration

The following engines now dispatch their validated and sanitized comparisons through the selected Driver:

- Ruleset
- Expression
- Tree

The execution flow is now:

```text
Request data
    ↓
Engine parsing
    ↓
Validation, mapping, and sanitization
    ↓
Payload
    ↓
Comparison operation
    ↓
Selected Driver
    ↓
Backend query
```

The `Payload` remains responsible for request lifecycle information and applied/skipped diagnostics. The `Comparison` operation contains the resolved field, operator, and final sanitized value used by the Driver.

### Tree Compatibility

Tree leaf comparisons are dispatched through the Driver, while the existing Tree grouping behavior remains unchanged in this PR.

The current Tree engine has legacy boolean-group semantics that differ from the new generic `Group` operation model. Replacing them in this lifecycle PR would change existing query results, so the full Tree group conversion is intentionally deferred to a dedicated PR with explicit compatibility tests.

### Invokable Compatibility

Invokable filter methods can contain arbitrary domain-specific Eloquent logic:

```php
protected function popular(Payload $payload): Builder
{
    return $this->builder
        ->where('views', '>', 1000)
        ->where('rating', '>=', 4);
}
```

These methods keep their existing behavior and are not automatically converted into Operations in this PR.

Portable Invokable methods that return Operations will be introduced separately.

### Driver Failure Safety

Added a shared `DriverException` marker for Driver infrastructure failures.

The following failures are now always surfaced instead of being silently swallowed by permissive filtering mode:

- Invalid Driver definitions
- Invalid backend query targets
- Unsupported Operations
- Results incompatible with the active execution lifecycle

Silently skipping these failures could return an unexpectedly unfiltered query, so they are treated differently from rejected user filter conditions.

### Driver Result Validation

Added `InvalidDriverResultException`.

The current v3 lifecycle starts with an Eloquent Builder. Drivers selected through `Filterable::useDriver()` must therefore return an Eloquent Builder until a generic backend execution target is introduced.

Returning an incompatible query object now fails explicitly.

### Documentation

Added a dedicated Filter Drivers guide covering:

- Driver selection
- Driver configuration
- The difference between Payloads and Operations
- DatabaseDriver capabilities
- Custom Driver registration
- Current Eloquent lifecycle constraints
- Invokable compatibility
- Driver failure behavior

Also updated:

- Documentation sidebar navigation
- How Filterable Works
- Changelog

## Backward Compatibility

This PR preserves the existing v3 public execution API:

- `Filterable::apply()` still accepts an Eloquent Builder.
- Eloquent remains the default backend.
- DatabaseDriver is resolved automatically.
- Existing applications require no configuration changes.
- Existing Ruleset, Expression, and Tree request formats remain unchanged.
- Applied and skipped Payload tracking remains unchanged.
- Existing Invokable filter methods continue to execute directly against Eloquent.
- The `filterable.resolved` event signature remains unchanged.
- `PayloadApplier` remains available for backward compatibility.

## Testing

Added lifecycle integration tests covering:

- Resolving the configured default Driver
- Overriding the Driver per Filterable instance
- Ruleset operation dispatch
- Expression operation dispatch
- Tree leaf operation dispatch
- Field mapping before Driver execution
- Sanitization before Driver execution
- Resolved operators passed to Drivers
- Preserving raw values in applied Payload tracking
- Existing Invokable behavior
- Rejecting incompatible Driver results
- Surfacing Driver failures safely

Full verification:

```text
523 tests
928 assertions
All passing
```

## Next Steps

Follow-up PRs will cover:

1. Converting Tree boolean groups into complete `Group` operation trees
2. Supporting portable Invokable methods that return Operations
3. Introducing a backend-neutral execution target
4. Adding the Meilisearch Driver
5. Adding Meilisearch integration and compatibility tests