### PR TITLE
Compile Tree filters into driver operation groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Ruleset, Expression, and Tree comparisons are dispatched through the selected
-  Driver while preserving the existing Eloquent lifecycle.
+- Ruleset and Expression comparisons are dispatched through the selected Driver,
+  while Tree dispatches its complete logical Operation tree in one Driver call.
 - Driver infrastructure failures are surfaced in strict and permissive modes
   instead of being silently skipped.
+
+### Fixed
+
+- Tree groups now join their children using the group's declared `AND` or `OR`
+  boolean, including across recursively nested groups.
 
 ## [3.0.0] - 2026-09-10
 

--- a/docs/engines/tree.md
+++ b/docs/engines/tree.md
@@ -1,12 +1,12 @@
 ---
 title: Tree Engine
-description: Translate nested AND and OR condition trees into grouped Eloquent queries.
+description: Translate nested AND and OR conditions into a portable operation tree.
 tags: [engines, tree, boolean logic, json]
 ---
 
 # Tree Engine
 
-The Tree engine turns nested JSON conditions into correctly grouped Eloquent constraints. Use it when the client must describe boolean logic, such as an advanced search builder with nested `AND` and `OR` groups.
+The Tree engine turns nested JSON conditions into a backend-independent operation tree. The selected [Driver](/features/drivers) then translates the complete tree for its query backend. Use it when the client must describe boolean logic, such as an advanced search builder with nested `AND` and `OR` groups.
 
 ## Choose Tree when
 
@@ -47,7 +47,7 @@ For ordinary operator filters, prefer the smaller [Ruleset](/engines/rule-set) o
 }
 ```
 
-Each group contains either `and` or `or`. Each leaf condition contains `field`, `operator`, and `value`.
+Each group contains either `and` or `or`, and that boolean joins all of its direct children. Each leaf condition contains `field`, `operator`, and `value`. Nested groups apply their own boolean independently, so the example means `status = published AND (views >= 100 OR featured = true)`.
 
 ## Minimal example
 
@@ -62,7 +62,7 @@ $posts = Filterable::for(Post::class, $request)
     ->paginate();
 ```
 
-The engine preserves group boundaries when it generates nested `where` and `orWhere` clauses.
+The engine compiles this request into nested `Group` and `Comparison` Operations and dispatches the root group to the selected Driver once. This preserves every group boundary without coupling Tree parsing to Eloquent. An empty group applies no query constraint.
 
 ## Provide a tree without an HTTP request
 
@@ -116,7 +116,7 @@ Strict mode is recommended for public Tree endpoints. It stops execution when a 
 ->allowedOperators(['eq', 'gte'])
 ```
 
-Permissive mode can skip rejected leaves, but malformed tree structure may still make the request unusable. Validate the incoming JSON shape before filtering.
+Permissive mode can omit rejected leaves while preserving the remaining group. Applied payloads are committed only after the Driver successfully applies the complete tree. Malformed tree structure may still make the request unusable, so validate the incoming JSON shape before filtering.
 
 ## Common mistakes
 

--- a/docs/features/drivers.md
+++ b/docs/features/drivers.md
@@ -13,7 +13,7 @@ Request data
     ↓
 Engine → validation and sanitization
     ↓
-Comparison operation
+Operation or operation tree
     ↓
 Driver
     ↓
@@ -58,7 +58,7 @@ Aliases and Driver classes are resolved through Laravel's service container, so 
 - An `Operation` describes the final backend-independent comparison that should be executed.
 - The selected Driver translates that Operation into backend-specific query calls.
 
-Ruleset, Expression, and Tree dispatch their resolved comparisons through the selected Driver. Applied and skipped state continues to store `Payload` snapshots, so existing diagnostics remain unchanged.
+Ruleset and Expression dispatch each resolved comparison through the selected Driver. Tree compiles the complete condition tree into nested `Group` and `Comparison` Operations, then dispatches it in one Driver call. Applied and skipped state continues to store `Payload` snapshots, so existing diagnostics remain unchanged.
 
 ## Database Driver
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -67,7 +67,7 @@ protected function status(Payload $payload): Builder
 }
 ```
 
-Ruleset, Expression, and Tree turn their resolved payloads into comparison operations and dispatch them through the selected [Driver](/features/drivers). Invokable methods keep direct control of their domain-specific Eloquent logic.
+Ruleset and Expression turn each resolved payload into a comparison Operation. Tree compiles all of its comparisons and logical groups into one operation tree. They dispatch these Operations through the selected [Driver](/features/drivers), while Invokable methods keep direct control of their domain-specific Eloquent logic.
 
 ## Safe filtering
 

--- a/src/Engines/Foundation/Engine.php
+++ b/src/Engines/Foundation/Engine.php
@@ -14,6 +14,7 @@ use Kettasoft\Filterable\Engines\Contracts\HasAllowedFieldChecker;
 use Kettasoft\Filterable\Engines\Contracts\HasInteractsWithOperators;
 use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
 use Kettasoft\Filterable\Exceptions\Contracts\DriverException;
 use Kettasoft\Filterable\Exceptions\InvalidDriverResultException;
 
@@ -191,11 +192,25 @@ abstract class Engine implements HasInteractsWithOperators, HasFieldMap, Stricta
    */
   final protected function dispatchPayload(Payload $payload, Builder $builder): Builder
   {
-    $driver = $this->context->getDriver();
-    $result = $driver->apply(
+    return $this->dispatchOperation(
       new Comparison($payload->field, $payload->operator, $payload->value),
       $builder
     );
+  }
+
+  /**
+   * Dispatch a backend-independent operation to the active driver.
+   *
+   * @param Operation $operation Operation or operation tree to apply.
+   * @param Builder $builder Eloquent builder receiving the operation.
+   * @return Builder The builder returned by the active driver.
+   *
+   * @throws InvalidDriverResultException When the driver returns a non-Eloquent result.
+   */
+  final protected function dispatchOperation(Operation $operation, Builder $builder): Builder
+  {
+    $driver = $this->context->getDriver();
+    $result = $driver->apply($operation, $builder);
 
     if (! $result instanceof Builder) {
       throw new InvalidDriverResultException($driver::class, $result, Builder::class);

--- a/src/Engines/Tree.php
+++ b/src/Engines/Tree.php
@@ -5,6 +5,9 @@ namespace Kettasoft\Filterable\Engines;
 use Illuminate\Contracts\Database\Eloquent\Builder;
 use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Support\TreeNode;
+use Kettasoft\Filterable\Operations\Comparison;
+use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Operations\Group;
 use Kettasoft\Filterable\Traits\FieldNormalizer;
 use Kettasoft\Filterable\Engines\Foundation\Engine;
 use Kettasoft\Filterable\Engines\Foundation\PayloadFactory;
@@ -26,43 +29,66 @@ class Tree extends Engine
    */
   public function execute(Builder $builder): Builder
   {
-    $data = $this->context->getData();
+    $payloads = [];
+    $operation = $this->compileNode(
+      TreeNode::parse($this->context->getData()),
+      $payloads
+    );
 
-    return $this->applyNode($builder, TreeNode::parse($data));
-  }
+    $builder = $this->dispatchOperation($operation, $builder);
 
-  /**
-   * Apply tree node to the query builder.
-   * @param \Illuminate\Contracts\Database\Eloquent\Builder $builder
-   * @param \Kettasoft\Filterable\Support\TreeNode $node
-   * @return Builder
-   */
-  private function applyNode(Builder $builder, TreeNode $node)
-  {
-    if ($node->isGroup()) {
-      $builder->where(function (Builder $query) use ($node) {
-        foreach ($node->children as $child) {
-          $this->attempt(function () use ($child, $query) {
-            $method = strtolower($child->logical) === 'and' ? 'where' : 'orWhere';
-
-            $query->{$method}(function ($sub) use ($child) {
-              $this->applyNode($sub, $child);
-            });
-          });
-        }
-      });
-    } else {
-
-      $payload = (new PayloadFactory($this))->make(
-        new Payload($node->field, $node->operator ?? $this->defaultOperator(), $this->sanitizeValue($node->field, $node->value), $node->value)
-      );
-
-      $builder = $this->dispatchPayload($payload, $builder);
-
-      $this->commit($node->field, $payload);
+    foreach ($payloads as [$key, $payload]) {
+      $this->commit($key, $payload);
     }
 
     return $builder;
+  }
+
+  /**
+   * Compile a parsed Tree node into a backend-independent Operation tree.
+   *
+   * Invalid children handled in permissive mode are omitted from their group.
+   * Valid payloads are collected and committed only after the Driver applies
+   * the complete tree successfully.
+   *
+   * @param TreeNode $node Parsed condition or logical group.
+   * @param array<int, array{0: string, 1: Payload}> $payloads Pending payloads.
+   * @return Operation Compiled comparison or logical group.
+   */
+  private function compileNode(TreeNode $node, array &$payloads): Operation
+  {
+    if ($node->isGroup()) {
+      $operations = [];
+
+      foreach ($node->children as $child) {
+        $operation = null;
+
+        $this->attempt(function () use ($child, &$operation, &$payloads): bool {
+          $operation = $this->compileNode($child, $payloads);
+
+          return true;
+        });
+
+        if ($operation instanceof Operation) {
+          $operations[] = $operation;
+        }
+      }
+
+      return new Group($node->logical, $operations);
+    }
+
+    $payload = (new PayloadFactory($this))->make(
+      new Payload(
+        $node->field,
+        $node->operator ?? $this->defaultOperator(),
+        $this->sanitizeValue($node->field, $node->value),
+        $node->value
+      )
+    );
+
+    $payloads[] = [$node->field, $payload];
+
+    return new Comparison($payload->field, $payload->operator, $payload->value);
   }
 
   /**

--- a/tests/Unit/Drivers/DriverLifecycleTest.php
+++ b/tests/Unit/Drivers/DriverLifecycleTest.php
@@ -10,6 +10,7 @@ use Kettasoft\Filterable\Exceptions\InvalidDriverResultException;
 use Kettasoft\Filterable\Filterable;
 use Kettasoft\Filterable\Operations\Comparison;
 use Kettasoft\Filterable\Operations\Contracts\Operation;
+use Kettasoft\Filterable\Operations\Group;
 use Kettasoft\Filterable\Support\Payload;
 use Kettasoft\Filterable\Tests\Models\Post;
 use Kettasoft\Filterable\Tests\TestCase;
@@ -78,7 +79,7 @@ class DriverLifecycleTest extends TestCase
     $this->assertComparison($driver->operations[0], 'views', '>=', 20);
   }
 
-  public function test_tree_dispatches_each_leaf_comparison_to_the_driver(): void
+  public function test_tree_dispatches_a_complete_operation_tree_to_the_driver(): void
   {
     $this->seedPosts();
     $driver = new RecordingDriver();
@@ -100,9 +101,16 @@ class DriverLifecycleTest extends TestCase
       ->useDriver($driver)
       ->get();
 
-    $this->assertCount(2, $driver->operations);
-    $this->assertComparison($driver->operations[0], 'status', '=', 'active');
-    $this->assertComparison($driver->operations[1], 'views', '>=', 30);
+    $this->assertCount(1, $driver->operations);
+    $this->assertInstanceOf(Group::class, $driver->operations[0]);
+    $this->assertSame('and', $driver->operations[0]->boolean());
+
+    [$status, $nested] = $driver->operations[0]->operations();
+
+    $this->assertComparison($status, 'status', '=', 'active');
+    $this->assertInstanceOf(Group::class, $nested);
+    $this->assertSame('or', $nested->boolean());
+    $this->assertComparison($nested->operations()[0], 'views', '>=', 30);
   }
 
   public function test_invokable_domain_methods_keep_their_existing_database_behavior(): void
@@ -144,6 +152,31 @@ class DriverLifecycleTest extends TestCase
       ->setAllowedFields(['views'])
       ->useDriver(new InvalidResultDriver())
       ->get();
+  }
+
+  public function test_tree_payloads_are_not_committed_when_the_driver_fails(): void
+  {
+    $this->seedPosts();
+    $request = Request::create('/posts');
+    $request->setJson(new InputBag([
+      'filter' => [
+        'and' => [
+          ['field' => 'status', 'operator' => 'eq', 'value' => 'active'],
+          ['field' => 'views', 'operator' => 'gte', 'value' => 10],
+        ],
+      ],
+    ]));
+    $filterable = Filterable::for(Post::class, $request)
+      ->using('tree')
+      ->setAllowedFields(['status', 'views'])
+      ->useDriver(new InvalidResultDriver());
+
+    try {
+      $filterable->get();
+      $this->fail('Expected the incompatible Driver result to fail.');
+    } catch (InvalidDriverResultException) {
+      $this->assertSame([], $filterable->applied());
+    }
   }
 
   private function assertComparison(

--- a/tests/Unit/Engines/TreeEngineTest.php
+++ b/tests/Unit/Engines/TreeEngineTest.php
@@ -315,15 +315,15 @@ class TreeEngineTest extends TestCase
    * It filter with tree based engin and enable strict mode option.
    * @test
    */
-  public function it_can_filter_with_or_and_logical_operator()
+  public function it_combines_or_and_nested_and_groups_by_their_declared_boolean()
   {
     $data = [
       "filter" => [
-        "and" => [
+        "or" => [
           ["field" => "status", "operator" => "eq", "value" => "stopped"],
-          ['or' => [
+          ['and' => [
+            ["field" => "content", "operator" => "null", "value" => null],
             ["field" => "status", "operator" => "eq", "value" => "active"],
-            ["field" => "status", "operator" => "eq", "value" => "pending"],
           ]]
         ]
       ]
@@ -334,7 +334,48 @@ class TreeEngineTest extends TestCase
       ->setAllowedFields(['*'])
       ->apply(Post::query());
 
-    $this->assertEquals(45, $filter->count());
+    $this->assertEquals(30, $filter->count());
+  }
+
+  public function test_it_combines_conditions_inside_an_and_group(): void
+  {
+    $data = [
+      'filter' => [
+        'and' => [
+          ['field' => 'status', 'operator' => 'eq', 'value' => 'active'],
+          ['field' => 'content', 'operator' => 'null', 'value' => null],
+        ],
+      ],
+    ];
+
+    $filter = Filterable::create()
+      ->setData($data, true)
+      ->setAllowedFields(['status', 'content'])
+      ->apply(Post::query());
+
+    $this->assertEquals(15, $filter->count());
+  }
+
+  public function test_permissive_mode_omits_only_the_rejected_leaf_from_a_group(): void
+  {
+    $data = [
+      'filter' => [
+        'and' => [
+          ['field' => 'status', 'operator' => 'eq', 'value' => 'active'],
+          ['field' => 'private_notes', 'operator' => 'eq', 'value' => 'hidden'],
+        ],
+      ],
+    ];
+
+    $filterable = Filterable::create()
+      ->permissive()
+      ->setData($data, true)
+      ->setAllowedFields(['status']);
+
+    $this->assertEquals(15, $filterable->apply(Post::query())->count());
+    $this->assertTrue($filterable->hasSkipped('private_notes'));
+    $this->assertNotNull($filterable->applied('status'));
+    $this->assertNull($filterable->applied('private_notes'));
   }
 
   public function test_it_sanitize_value_before_applying_to_query()


### PR DESCRIPTION
## Summary

This PR completes Driver integration for the Tree engine by compiling the entire filter tree into backend-independent `Group` and `Comparison` operations.

## What changed

- Dispatch the complete Tree operation through the selected Driver once.
- Preserve nested `AND` and `OR` group boundaries.
- Fix boolean semantics so each group joins its own children.
- Commit applied payloads only after successful Driver execution.
- Preserve permissive-mode behavior by omitting rejected leaves.
- Update the Driver, Tree engine, and lifecycle documentation.